### PR TITLE
Updates according to conviva validation feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Added
+- Tracking of `autoplay` and `preload` config attributes
+
 ### Changed
 - Updated Conviva-SDK to 2.146.0.36444
+- Bind `PlayerStateManager`'s lifecycle to the lifecycle of the `Client`
 
 ## [95c526]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Tracking of `autoplay` and `preload` config attributes
+- Live stream support
 
 ### Changed
 - Updated Conviva-SDK to 2.146.0.36444

--- a/src/html/test.html
+++ b/src/html/test.html
@@ -107,7 +107,10 @@
     applicationName: 'Bitmovin Player Conviva Analytics Integration Test Page',
     viewerId: 'uniqueViewerId',
     customTags: {
-      contentType: 'Episode',
+      appVersion: '1.0',
+      contentId: 'someContentId',
+      playerVendor: 'bitmovin',
+      playerVersion: player.version
     },
   });
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -540,9 +540,9 @@ class PlayerConfigHelper {
   /**
    * Extract preload config from player
    *
-   * The preload config can be set individual for mobile or desktop.
-   * Default value is true for VOD and false for live streams. If the value is not set for current platform
-   * the default value will be used over the value for the other platform.
+   * The preload config can be set individual for mobile or desktop as well as on root level for both platforms.
+   * Default value is true for VOD and false for live streams. If the value is not set for current platform or on root
+   * level the default value will be used over the value for the other platform.
    *
    * @param player: Player
    */
@@ -561,6 +561,11 @@ class PlayerConfigHelper {
           && playerConfig.adaptation.desktop.preload !== undefined) {
         return playerConfig.adaptation.desktop.preload;
       }
+    }
+
+    if (playerConfig.adaptation
+        && playerConfig.adaptation.preload !== undefined) {
+      return playerConfig.adaptation.preload
     }
 
     return !player.isLive();

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -405,6 +405,11 @@ export class ConvivaAnalytics {
   };
 
   private onError = (event: any) => {
+    if (!this.isValidSession()) {
+      // initialize Session if not yet initialized to capture Video Start Failures
+      this.initializeSession();
+    }
+
     this.client.reportError(this.sessionKey, String(event.code) + ' ' + event.message,
       Conviva.Client.ErrorSeverity.FATAL);
     this.endSession();

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -328,7 +328,8 @@ export class ConvivaAnalytics {
       return;
     }
 
-    this.playerStateManager.setPlayerSeekStart(Math.round(event.target * 1000));
+    // According to conviva it is valid to pass -1 for seeking in live streams
+    this.playerStateManager.setPlayerSeekStart(-1);
   };
 
   private onTimeShifted = () => {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -169,6 +169,7 @@ export class ConvivaAnalytics {
 
     // Create a Conviva monitoring session.
     this.sessionKey = this.client.createSession(this.contentMetadata); // this will make the initial request
+    this.updateSession();
 
     if (!this.isValidSession()) {
       // Something went wrong. With stable system interfaces, this should never happen.

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -337,6 +337,11 @@ export class ConvivaAnalytics {
   };
 
   private onSeeked = () => {
+    if (!this.isValidSession()) {
+      // See comment in onSeek
+      return;
+    }
+
     this.playerStateManager.setPlayerSeekEnd();
   };
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -244,6 +244,11 @@ export class ConvivaAnalytics {
 
   private onPlaybackStateChanged = (event?: any) => {
     this.debugLog('reportplaybackstate', event);
+    if (event && event.issuer === 'IMA') {
+      // Do not track playback state changes from IMA
+      return;
+    }
+
     let playerState;
 
     if (this.player.isStalled()) {
@@ -263,6 +268,10 @@ export class ConvivaAnalytics {
 
   private onPlay = (event: any) => {
     this.debugLog('play', event);
+    if (event.issuer === 'IMA') {
+      // Do not track play event from IMA
+      return;
+    }
 
     // in case the playback has finished and the user replays the stream create a new session
     if (!this.isValidSession()) {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -194,12 +194,7 @@ export class ConvivaAnalytics {
     this.contentMetadata.streamType =
       this.player.isLive() ? Conviva.ContentMetadata.StreamType.LIVE : Conviva.ContentMetadata.StreamType.VOD;
 
-    this.contentMetadata.custom = {
-      'playerType': this.player.getPlayerType(),
-      'streamType': this.player.getStreamType(),
-      'vrContentType': this.player.getVRStatus().contentType,
-      ...this.config.customTags,
-    };
+    this.contentMetadata.custom = this.config.customTags;
   }
 
   /**

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -313,7 +313,26 @@ export class ConvivaAnalytics {
   };
 
   private onSeek = (event: any) => {
+    if (!this.isValidSession()) {
+      // Handle use case when startTime is set.
+      // Then seek is called before the user show intention to play content so do not track seek in this case.
+      return;
+    }
+
     this.playerStateManager.setPlayerSeekStart(Math.round(event.seekTarget * 1000));
+  };
+
+  private onTimeShift = (event: any) => {
+    if (!this.isValidSession()) {
+      // See comment in onSeek
+      return;
+    }
+
+    this.playerStateManager.setPlayerSeekStart(Math.round(event.target * 1000));
+  };
+
+  private onTimeShifted = () => {
+    this.onSeeked();
   };
 
   private onSeeked = () => {
@@ -432,7 +451,9 @@ export class ConvivaAnalytics {
     playerEvents.add(player.EVENT.ON_STALL_ENDED, this.onPlaybackStateChanged);
     playerEvents.add(player.EVENT.ON_PLAYBACK_FINISHED, this.onPlaybackFinished);
     playerEvents.add(player.EVENT.ON_SEEK, this.onSeek);
+    playerEvents.add(player.EVENT.ON_TIME_SHIFT, this.onTimeShift);
     playerEvents.add(player.EVENT.ON_SEEKED, this.onSeeked);
+    playerEvents.add(player.EVENT.ON_TIME_SHIFTED, this.onTimeShifted);
     playerEvents.add(player.EVENT.ON_VIDEO_PLAYBACK_QUALITY_CHANGED, this.onVideoQualityChanged);
     playerEvents.add(player.EVENT.ON_AUDIO_PLAYBACK_QUALITY_CHANGED, this.onCustomEvent);
     playerEvents.add(player.EVENT.ON_MUTED, this.onCustomEvent);

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -239,30 +239,6 @@ export class ConvivaAnalytics {
     return this.sessionKey !== Conviva.Client.NO_SESSION_KEY;
   }
 
-  private onSourceLoaded = () => {
-    if (this.isAd) {
-      // Ignore ON_SOURCE_LOADED events during ad playback, because that's just an ad being temporarily loaded
-      // instead of the actual source.
-      return;
-    }
-
-    // in case a source has been loaded after an source_unloaded initialize a new session
-    if (!this.isValidSession()) {
-      this.initializeSession();
-    }
-  };
-
-  private onReady = (event: any) => {
-    this.debugLog('ready', event);
-
-    // initialize if not yet initialized but only when a not empty source is present
-    const source = this.player.getConfig().source;
-    const isSourcePresent = source && Object.keys(source).length > 0;
-    if (!this.isValidSession() && isSourcePresent) {
-      this.initializeSession();
-    }
-  };
-
   private onPlaybackStateChanged = (event?: any) => {
     this.debugLog('reportplaybackstate', event);
     let playerState;
@@ -428,8 +404,6 @@ export class ConvivaAnalytics {
   private registerPlayerEvents(): void {
     let player = this.player;
     let playerEvents = this.playerEvents;
-    playerEvents.add(player.EVENT.ON_SOURCE_LOADED, this.onSourceLoaded);
-    playerEvents.add(player.EVENT.ON_READY, this.onReady);
     playerEvents.add(player.EVENT.ON_PLAY, this.onPlay);
     playerEvents.add(player.EVENT.ON_PLAYING, this.onPlaying);
     playerEvents.add(player.EVENT.ON_TIME_CHANGED, this.onTimeChanged);

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -114,10 +114,6 @@ export class ConvivaAnalytics {
 
     this.client = new Conviva.Client(clientSettings, this.systemFactory);
 
-    this.playerStateManager = this.client.getPlayerStateManager();
-    this.playerStateManager.setPlayerType('Bitmovin Player');
-    this.playerStateManager.setPlayerVersion(player.version);
-
     this.registerPlayerEvents();
   }
 
@@ -164,6 +160,11 @@ export class ConvivaAnalytics {
    *  - encodedFrameRate (unused)
    */
   private initializeSession() {
+    // initialize PlayerStateManager
+    this.playerStateManager = this.client.getPlayerStateManager();
+    this.playerStateManager.setPlayerType('Bitmovin Player');
+    this.playerStateManager.setPlayerVersion(this.player.version);
+
     this.contentMetadata = new Conviva.ContentMetadata();
     this.buildContentMetadata();
 
@@ -231,6 +232,8 @@ export class ConvivaAnalytics {
     this.debugLog('endsession', this.sessionKey, event);
     this.client.detachPlayer(this.sessionKey);
     this.client.cleanupSession(this.sessionKey);
+    this.client.releasePlayerStateManager(this.playerStateManager);
+
     this.sessionKey = Conviva.Client.NO_SESSION_KEY;
     this.sessionDataPopulated = false;
   };
@@ -463,7 +466,6 @@ export class ConvivaAnalytics {
   release(): void {
     this.unregisterPlayerEvents();
     this.endSession();
-    this.client.releasePlayerStateManager(this.playerStateManager);
     this.client.release();
     this.systemFactory.release();
   }


### PR DESCRIPTION
## Description
Changes requested by the verification process of conviva:
- Initialize session only when the user requests playback (when the user presses play or autoplay content) - Was pointed out by a wrong VST (Video Startup Time)
- Bind lifecycle from the `PlayerStateManager` to the lifecycle of the `convivaSession`
- Track VSF (Video Startup Failures)
- Do not track events from the ad player

Suggestions from conviva:
- Track `autoplay` and `preload` config since they are affecting VST
- Add customTags for:
  - appVersion
  - contentId
  - playerVendor
  - playerVersion (also tracked automatic in `PlayerStateManager`)
