### PR TITLE
Minor improvements regarding conviva validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Conviva-SDK to 2.146.0.36444
 - Bind `PlayerStateManager`'s lifecycle to the lifecycle of the `Client`
 
+### Removed
+- Seek event tracking
+
 ## [95c526]
 
 Support for Conviva-SDK version below 2.146.0.36444

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -299,12 +299,6 @@ export class ConvivaAnalytics {
   };
 
   private onPlaying = (event: any) => {
-    // When seeking over the buffer the player emits an onPlaying event followed by an onStallStarted within 0 ms.
-    // To suppress this play state transition we check the buffer if the video element is really ready to start playing.
-    if (this.player.getVideoBufferLength() === 0) {
-      this.debugLog('no buffer - skipped playing event', event);
-      return;
-    }
     this.playbackStarted = true;
     this.debugLog('playing', event);
     this.updateSession();
@@ -323,39 +317,6 @@ export class ConvivaAnalytics {
     this.debugLog('playbackfinished', event);
     this.onPlaybackStateChanged(event);
     this.endSession(event);
-  };
-
-  private onSeek = (event: any) => {
-    if (!this.isValidSession()) {
-      // Handle use case when startTime is set.
-      // Then seek is called before the user show intention to play content so do not track seek in this case.
-      return;
-    }
-
-    this.playerStateManager.setPlayerSeekStart(Math.round(event.seekTarget * 1000));
-  };
-
-  private onTimeShift = (event: any) => {
-    if (!this.isValidSession()) {
-      // See comment in onSeek
-      return;
-    }
-
-    // According to conviva it is valid to pass -1 for seeking in live streams
-    this.playerStateManager.setPlayerSeekStart(-1);
-  };
-
-  private onTimeShifted = () => {
-    this.onSeeked();
-  };
-
-  private onSeeked = () => {
-    if (!this.isValidSession()) {
-      // See comment in onSeek
-      return;
-    }
-
-    this.playerStateManager.setPlayerSeekEnd();
   };
 
   private onVideoQualityChanged = (event: any) => {
@@ -471,10 +432,6 @@ export class ConvivaAnalytics {
     playerEvents.add(player.EVENT.ON_STALL_STARTED, this.onPlaybackStateChanged);
     playerEvents.add(player.EVENT.ON_STALL_ENDED, this.onPlaybackStateChanged);
     playerEvents.add(player.EVENT.ON_PLAYBACK_FINISHED, this.onPlaybackFinished);
-    playerEvents.add(player.EVENT.ON_SEEK, this.onSeek);
-    playerEvents.add(player.EVENT.ON_TIME_SHIFT, this.onTimeShift);
-    playerEvents.add(player.EVENT.ON_SEEKED, this.onSeeked);
-    playerEvents.add(player.EVENT.ON_TIME_SHIFTED, this.onTimeShifted);
     playerEvents.add(player.EVENT.ON_VIDEO_PLAYBACK_QUALITY_CHANGED, this.onVideoQualityChanged);
     playerEvents.add(player.EVENT.ON_AUDIO_PLAYBACK_QUALITY_CHANGED, this.onCustomEvent);
     playerEvents.add(player.EVENT.ON_MUTED, this.onCustomEvent);

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -410,7 +410,9 @@ export class ConvivaAnalytics {
 
   private onAdError = (event: any) => {
     this.onCustomEvent(event);
-    this.onAdFinished(event);
+    if (this.isAd) {
+      this.onAdFinished(event);
+    }
   };
 
   private onAdFinished = (event?: any) => {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -170,7 +170,6 @@ export class ConvivaAnalytics {
 
     // Create a Conviva monitoring session.
     this.sessionKey = this.client.createSession(this.contentMetadata); // this will make the initial request
-    this.updateSession();
 
     if (!this.isValidSession()) {
       // Something went wrong. With stable system interfaces, this should never happen.
@@ -205,16 +204,24 @@ export class ConvivaAnalytics {
       'preload': PlayerConfigHelper.getPreloadConfig(this.player) + '',
       ...this.config.customTags,
     };
+
+    // also include dynamic content metadata at initial creation
+    this.buildDynamicContentMetadata();
   }
 
   /**
    * Update contentMetadata which are allowed during the session
    */
+  private buildDynamicContentMetadata() {
+    let source = this.player.getConfig().source;
+    this.contentMetadata.streamUrl = this.getUrlFromSource(source);
+  }
+
   private updateSession() {
     if (!this.isValidSession()) {
       return;
     }
-    this.contentMetadata.streamUrl = this.getUrlFromSource(this.player.getConfig().source);
+    this.buildDynamicContentMetadata();
     this.client.updateContentMetadata(this.sessionKey, this.contentMetadata);
   }
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -299,6 +299,12 @@ export class ConvivaAnalytics {
   };
 
   private onPlaying = (event: any) => {
+    // When seeking over the buffer the player emits an onPlaying event followed by an onStallStarted within 0 ms.
+    // To suppress this play state transition we check the buffer if the video element is really ready to start playing.
+    if (this.player.getVideoBufferLength() === 0) {
+      this.debugLog('no buffer - skipped playing event', event);
+      return;
+    }
     this.playbackStarted = true;
     this.debugLog('playing', event);
     this.updateSession();


### PR DESCRIPTION
## Description
There are some more requests to change from conviva.

- Do not track adFinished events if an adError occured but no ad ever started.
- Do not track playing events if it transits into stalled within nearly 0 ms
- Send all available content metadata attributes right on session creation.

## Fix
Fix for the second issue is to check if the buffer is 0 in the playing event. If yes we do not report this event. As discussed with @bitmovin-kenny this playing event is natural behavior of the video-element.