### PR TITLE
Improve suppressing play-state event during ads

### DIFF
--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -259,8 +259,8 @@ export class ConvivaAnalytics {
 
   private onPlaybackStateChanged = (event?: any) => {
     this.debugLog('reportplaybackstate', event);
-    if (event && event.issuer === 'IMA') {
-      // Do not track playback state changes from IMA
+    if (this.isAd) {
+      // Do not track playback state changes during ad (e.g. triggered from IMA)
       return;
     }
 
@@ -283,8 +283,8 @@ export class ConvivaAnalytics {
 
   private onPlay = (event: any) => {
     this.debugLog('play', event);
-    if (event.issuer === 'IMA') {
-      // Do not track play event from IMA
+    if (this.isAd) {
+      // Do not track play event during ad (e.g. triggered from IMA)
       return;
     }
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -320,6 +320,9 @@ export class ConvivaAnalytics {
   };
 
   private onVideoQualityChanged = (event: any) => {
+    if (!this.isValidSession()) {
+      return;
+    }
     // We calculate the bitrate with a divisor of 1000 so the values look nicer
     // Example: 250000 / 1000 => 250 kbps (250000 / 1024 => 244kbps)
     let bitrateKbps = Math.round(event.targetQuality.bitrate / 1000);


### PR DESCRIPTION
## Description
As pointed out by @offnertho in #5 the check to suppress play state events during an ad was not ideal. This might be a better solution.

## Fix
- Use the existing `isAd` flag to suppress play state events.
- Prevent accessing the `playerStateManager` when no active session is running.