### PR TITLE
Fix an issue that a post-roll ad was tracked as a new conviva session

### DIFF
--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -424,6 +424,10 @@ export class ConvivaAnalytics {
     this.endSession(event);
   };
 
+  private onDestroy = (event: any) => {
+    this.endSession(event);
+  };
+
   // The adStarted event is triggered after the playing event of the ad so we need to set the isAd flag when an
   // adBreakStarts instead
   private onAdBreakStarted = (event: any) => {
@@ -462,6 +466,7 @@ export class ConvivaAnalytics {
     playerEvents.add(player.EVENT.ON_AD_ERROR, this.onAdError);
     playerEvents.add(player.EVENT.ON_SOURCE_UNLOADED, this.onSourceUnloaded);
     playerEvents.add(player.EVENT.ON_ERROR, this.onError);
+    playerEvents.add(player.EVENT.ON_DESTROY, this.onDestroy);
   }
 
   private unregisterPlayerEvents(): void {


### PR DESCRIPTION
## Description
We are creating a new session when an `onPlaying` gets triggered. This will be also triggered when an ad starts. We suppress this `playing` event with the `isAd` flag but the `adStarted` event comes after a `playing` event of an ad. So we created a new session for a post-roll ad.

## Fix
Set the `isAd` flag within the `adBreakStarted` / `adBreakFinished` events.

Minor improvement:
- only log events when we actually report them.
- close session on player destroy