### PR TITLE
Add possibility to track custom deficiency events

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 **This version of the Conviva Analytics Integration works only with Player Version 7.x.
 The recommended version of the Conviva SDK is 2.146.0.36444.** See [CHANGELOG](CHANGELOG.md) for details.
 
-## Limitations
-This Conviva integration currently does not track pre-roll ads. The analytics session is created after pre-roll ads, before the main content is started. This is implemented according to Conviva's guidelines but is still considered a limitation as the `Exit Before Video Start` metrics cannot be measured. All other metrics are working as expected.
-
 ## Getting Started
 
  0. Clone Git repository
@@ -65,4 +62,19 @@ To just take a look at the project, also run `gulp serve`.
     }
     ```
  5. Release the instance by calling `conviva.release()` before destroying the player by calling `player.destroy()`
+ 
+### Advanced Usage
+
+#### VPF tracking
+
+If you would like to track custom VPF (Video Playback Failures) events when no actual player error happens (e.g. 
+the server closes the connection and return `net::ERR_EMPTY_RESPONSE` or after a certain time of stalling)
+you can use following API to track those deficiencies.
+
+```js
+conviva.reportPlaybackDeficiency('Some Error Message', Conviva.Client.ErrorSeverity.FATAL);
+```
+_See [ConvivaAnalytics.ts](./src/ts/ConvivaAnalytics.ts) for parameter details._
+
+Conviva suggests an timeout of about ~10 seconds and before reporting an error to conviva and providing feedback the user.
  

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -405,14 +405,7 @@ export class ConvivaAnalytics {
   };
 
   private onError = (event: any) => {
-    if (!this.isValidSession()) {
-      // initialize Session if not yet initialized to capture Video Start Failures
-      this.initializeSession();
-    }
-
-    this.client.reportError(this.sessionKey, String(event.code) + ' ' + event.message,
-      Conviva.Client.ErrorSeverity.FATAL);
-    this.endSession();
+    this.reportPlaybackDeficiency(String(event.code) + ' ' + event.message, Conviva.Client.ErrorSeverity.FATAL);
   };
 
   private onSourceUnloaded = (event: any) => {
@@ -498,6 +491,25 @@ export class ConvivaAnalytics {
     }
 
     this.client.sendCustomEvent(this.sessionKey, eventName, eventAttributes);
+  }
+
+  /**
+   * Sends a custom deficiency event during playback to Conviva's Player Insight. If no session is active it will NOT
+   * create one.
+   *
+   * @param message Message which will be send to conviva
+   * @param severity One of FATAL or WARNING
+   * @param endSession Boolean flag if session should be closed after reporting the deficiency (Default: true)
+   */
+  reportPlaybackDeficiency(message: string, severity: Conviva.Client.ErrorSeverity, endSession: boolean = true) {
+    if (!this.isValidSession()) {
+      return;
+    }
+
+    this.client.reportError(this.sessionKey, message, severity);
+    if (endSession) {
+      this.endSession();
+    }
   }
 
   release(): void {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -405,6 +405,11 @@ export class ConvivaAnalytics {
   };
 
   private onError = (event: any) => {
+    if (!this.isValidSession()) {
+      // initialize Session if not yet initialized to capture Video Start Failures
+      this.initializeSession();
+    }
+
     this.reportPlaybackDeficiency(String(event.code) + ' ' + event.message, Conviva.Client.ErrorSeverity.FATAL);
   };
 


### PR DESCRIPTION
## Description
Since we don't want to add a timeout in certain use-cases where the player stalls for a long time we now add a method where the user of the integration can decide if they want to track a deficiency to conviva.

_In the future there will be more methods to track custom session events._

## TODO

- [x] forward port