### PR TITLE
Add tracking support based on player events in v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `initializeSession` to external start session
 - `endSession` to external end session
 - `updateContentMetadata` to update content metadata after initializing `ConvivaAnalytics`
+- Support for Player v8 events
 
 ### Changed
-- Update to Bitmovin Player v8
+- Update to Bitmovin Player v8 API
 - Switch to Webpack
 - Improve typings
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bitmovin Player Conviva Analytics Integration
 
 ## Compatibility
-**This version of the Conviva Analytics Integration works only with Player Version 8.x.
+**This version of the Conviva Analytics Integration works only with Player Version >= 8.2.x.
 The recommended version of the Conviva SDK is 2.146.0.36444.** See [CHANGELOG](CHANGELOG.md) for details.
 
 ## Getting Started
@@ -34,8 +34,6 @@ The recommended version of the Conviva SDK is 2.146.0.36444.** See [CHANGELOG](C
     var conviva = new bitmovin.player.analytics.ConvivaAnalytics(player, 'CUSTOMER_KEY', {
       debugLoggingEnabled: true, // optional
       gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // optional, TOUCHSTONE_SERVICE_URL for testing
-      applicationName: 'Bitmovin Player Conviva Analytics Integration Test Page', // optional
-      viewerId: 'uniqueViewerId', // optional
     });
     
     var sourceConfig = {

--- a/example/index.html
+++ b/example/index.html
@@ -78,7 +78,9 @@
     function getPlayerConfig() {
       return {
         key: 'YOUR-PLAYER-KEY',
-        playback: {},
+        playback: {
+          muted: true,
+        },
         style: {},
         cast: {
           enable: true

--- a/example/index.html
+++ b/example/index.html
@@ -32,7 +32,7 @@
         box-shadow: 0 0 30px rgba(0,0,0,0.7);
       }
     </style>
-    <script src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
+    <script src="https://cdn.bitmovin.com/player/web/staging/8/bitmovinplayer.js"></script>
     <script src="./conviva-core-sdk.min.js"></script>
     <script src="./dist/bitmovinplayer-analytics-conviva.js"></script>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -362,7 +362,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -519,9 +519,15 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.0.3.tgz",
-      "integrity": "sha512-Kstgc70iThzW3DEaoGpb7uvasr3RS17biSAeH5cn+cAUnjvYl+4ZGNIT8djwAAWR7Ijkz1/A6FoXF1kyWtJsZQ==",
+      "version": "8.2.0-rc2",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.2.0-rc2.tgz",
+      "integrity": "sha512-V1L+MS/OCWe4SgQ4D043ZYsA4V6iNq2Agpro69MZ5vJw0bawYcMYLsttGIvpNMfO/NYwdpN+Y10ZPSu7/f4JAQ==",
+      "dev": true
+    },
+    "bitmovin-player-ui": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.3.1.tgz",
+      "integrity": "sha512-gY/gkUnqltGtdry9srQNWFRH2dMxg5mfeHVgHtoTF66nDEKwQ85Z9QV6KPigCtu50ruI+QboiNUqD3U12HD0+A==",
       "dev": true
     },
     "bluebird": {
@@ -615,7 +621,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -652,7 +658,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -686,7 +692,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1058,7 +1064,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -1071,7 +1077,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -1255,7 +1261,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -1838,7 +1844,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1859,12 +1866,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1879,17 +1888,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2006,7 +2018,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2018,6 +2031,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2032,6 +2046,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2039,12 +2054,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2063,6 +2080,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2143,7 +2161,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2155,6 +2174,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2240,7 +2260,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2276,6 +2297,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2295,6 +2317,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2338,12 +2361,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3596,7 +3621,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -4141,7 +4166,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -4744,7 +4769,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -4965,7 +4990,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "Bitmovin",
   "license": "ISC",
   "devDependencies": {
-    "bitmovin-player": "^8.0.3",
+    "bitmovin-player": "8.2.0-rc2",
+    "bitmovin-player-ui": "^3.3.1",
     "ts-loader": "^5.3.1",
     "tslint": "^5.11.0",
     "typescript": "^3.2.2",

--- a/src/ts/ContentMetadataBuilder.ts
+++ b/src/ts/ContentMetadataBuilder.ts
@@ -106,8 +106,8 @@ export class ContentMetadataBuilder {
 
   get custom(): CustomContentMetadata {
     return {
-      ...this.metadata.custom,
       ...this.metadataOverrides.custom,
+      ...this.metadata.custom, // Keep our custom tags in case someone tries to override them
     };
   }
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -250,7 +250,6 @@ export class ConvivaAnalytics {
     this.contentMetadata.applicationName = this.config.applicationName || 'Unknown (no config.applicationName set)';
     this.contentMetadata.assetName = this.getAssetName(source);
     this.contentMetadata.viewerId = source.viewerId || this.config.viewerId || null;
-    this.contentMetadata.duration = this.player.getDuration();
     this.contentMetadata.streamType =
       this.player.isLive() ? Conviva.ContentMetadata.StreamType.LIVE : Conviva.ContentMetadata.StreamType.VOD;
 
@@ -274,6 +273,7 @@ export class ConvivaAnalytics {
   private buildDynamicContentMetadata() {
     const source = this.player.getSource();
     this.contentMetadata.streamUrl = this.getUrlFromSource(source);
+    this.contentMetadata.duration = this.player.getDuration();
   }
 
   private updateSession() {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -1,13 +1,6 @@
 import {
-  AdBreak,
-  AdBreakEvent, AdEvent,
-  ErrorEvent,
-  PlaybackEvent,
-  PlayerAPI,
-  PlayerEvent,
-  PlayerEventBase, SeekEvent,
-  SourceConfig, TimeShiftEvent,
-  VideoQualityChangedEvent,
+  AdBreak, AdBreakEvent, AdEvent, ErrorEvent, PlaybackEvent, PlayerAPI, PlayerEvent, PlayerEventBase, SeekEvent,
+  SourceConfig, TimeShiftEvent, VideoQualityChangedEvent,
 } from 'bitmovin-player';
 import { Html5Http } from './Html5Http';
 import { Html5Logging } from './Html5Logging';

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -529,7 +529,7 @@ export class ConvivaAnalytics {
 
   private onSourceUnloaded = (event: PlayerEventBase) => {
     if (this.isAd) {
-      // Ignore ON_SOURCE_UNLOADED events while
+      // Ignore sourceUnloaded events during ads
       return;
     }
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -453,7 +453,6 @@ export class ConvivaAnalytics {
 
     if (this.isAd) {
       // Do not track play event during ad (e.g. triggered from IMA)
-      console.log('[log] returning cause of ad (onplay)');
       return;
     }
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -65,14 +65,14 @@ export class ConvivaAnalytics {
    */
   private isAd: boolean;
 
+  // Attributes needed to workaround wrong event order in case of a pre-roll ad. (See #onAdBreakStarted for more info)
+  private adBreakStartedToFire: AdBreakEvent;
+
   // Since there are no stall events during play / playing; seek / seeked; timeShift / timeShifted we need
   // to track stalling state between those events. To prevent tracking eg. when seeking in buffer we delay it.
   private stallTrackingTimout: Timeout = new Timeout(ConvivaAnalytics.STALL_TRACKING_DELAY_MS, () => {
     this.playerStateManager.setPlayerState(Conviva.PlayerStateManager.PlayerState.BUFFERING);
   });
-
-  // Attributes needed to workaround wrong event order in case of a pre-roll ad. (See #onAdBreakStarted for more info)
-  private adBreakStartedToFire: AdBreakEvent;
 
   constructor(player: Player, customerKey: string, config: ConvivaAnalyticsConfiguration = {}) {
     if (typeof Conviva === 'undefined') {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -73,7 +73,6 @@ export class ConvivaAnalytics {
   });
 
   // Attributes needed to workaround wrong event order in case of a pre-roll ad. (See #onAdBreakStarted for more info)
-  private initialPlayback: boolean = true;
   private adBreakStartedToFire: AdBreakEvent;
 
   constructor(player: Player, customerKey: string, config: ConvivaAnalyticsConfiguration = {}) {
@@ -463,8 +462,6 @@ export class ConvivaAnalytics {
   private onPlay = (event: PlaybackEvent) => {
     this.debugLog('[ Player Event ] play', event);
 
-    this.initialPlayback = false;
-
     if (this.isAd) {
       // Do not track play event during ad (e.g. triggered from IMA)
       console.log('[log] returning cause of ad (onplay)');
@@ -493,7 +490,6 @@ export class ConvivaAnalytics {
       return;
     }
 
-    this.initialPlayback = true;
     this.onPlaybackStateChanged(event);
     this.internalEndSession(event);
   };
@@ -692,12 +688,8 @@ export class ConvivaAnalytics {
     // a to early triggered adBreakStarted event. The initial onPlay event is called after the AdBreakStarted
     // of the pre-roll ad so we won't initialize a session. Therefore we save the adBreakStarted event and
     // trigger it in the initial onPlay event (after initializing the session). (See #onPlaybackStateChanged)
-
-    // TODO: can we use isValidSession here?
-    if (this.initialPlayback) {
+    if (!this.isValidSession()) {
       this.adBreakStartedToFire = event;
-      // TODO: reset to true after replay
-      this.initialPlayback = false;
     } else {
       this.trackAdBreakStarted(event);
     }

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -328,26 +328,26 @@ export class ConvivaAnalytics {
     let playerState;
 
     switch (event.type) {
-      case PlayerEvent.Play:
-      case PlayerEvent.Seek:
-      case PlayerEvent.TimeShift:
+      case this.events.Play:
+      case this.events.Seek:
+      case this.events.TimeShift:
         this.stallTrackingTimout.start();
         break;
-      case PlayerEvent.StallStarted:
+      case this.events.StallStarted:
         this.stallTrackingTimout.clear();
         playerState = Conviva.PlayerStateManager.PlayerState.BUFFERING;
         break;
-      case PlayerEvent.Playing:
+      case this.events.Playing:
         this.stallTrackingTimout.clear();
         playerState = Conviva.PlayerStateManager.PlayerState.PLAYING;
         break;
-      case PlayerEvent.Paused:
+      case this.events.Paused:
         this.stallTrackingTimout.clear();
         playerState = Conviva.PlayerStateManager.PlayerState.PAUSED;
         break;
-      case PlayerEvent.Seeked:
-      case PlayerEvent.TimeShifted:
-      case PlayerEvent.StallEnded:
+      case this.events.Seeked:
+      case this.events.TimeShifted:
+      case this.events.StallEnded:
         this.stallTrackingTimout.clear();
         if (this.player.isPlaying()) {
           playerState = Conviva.PlayerStateManager.PlayerState.PLAYING;
@@ -355,7 +355,7 @@ export class ConvivaAnalytics {
           playerState = Conviva.PlayerStateManager.PlayerState.PAUSED;
         }
         break;
-      case PlayerEvent.PlaybackFinished:
+      case this.events.PlaybackFinished:
         this.stallTrackingTimout.clear();
         playerState = Conviva.PlayerStateManager.PlayerState.STOPPED;
         break;

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -317,8 +317,9 @@ export class ConvivaAnalytics {
   }
 
   private onPlaybackStateChanged = (event: PlayerEventBase) => {
-    if (this.isAd) {
-      // Do not track playback state changes during ad (e.g. triggered from IMA)
+    // Do not track playback state changes during ads, (e.g. triggered from IMA)
+    // or if there is no active session.
+    if (this.isAd || !this.isValidSession()) {
       return;
     }
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -454,21 +454,43 @@ export class ConvivaAnalytics {
   };
 
   private onSeek = (event: SeekEvent) => {
+    if (!this.isValidSession()) {
+      // Handle the case that the User seeks on the UI before play was triggered.
+      // This also handles startTime feature. The same applies for onTimeShift.
+      return;
+    }
+
     this.trackSeekStart(event.seekTarget);
     this.onPlaybackStateChanged(event);
   };
 
   private onSeeked = (event: SeekEvent) => {
+    if (!this.isValidSession()) {
+      // See comment in onSeek
+      return;
+    }
+
     this.trackSeekEnd();
     this.onPlaybackStateChanged(event);
   };
 
   private onTimeShift = (event: TimeShiftEvent) => {
+    if (!this.isValidSession()) {
+      // See comment in onSeek
+      return;
+    }
+
+    // According to conviva it is valid to pass -1 for seeking in live streams
     this.trackSeekStart(-1);
     this.onPlaybackStateChanged(event);
   };
 
   private onTimeShifted = (event: TimeShiftEvent) => {
+    if (!this.isValidSession()) {
+      // See comment in onSeek
+      return;
+    }
+
     this.trackSeekEnd();
     this.onPlaybackStateChanged(event);
   };

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -80,7 +80,6 @@ export class ConvivaAnalytics {
    */
   private isAd: boolean;
 
-  private playbackStarted: boolean;
   // Since there are no stall events during play / playing; seek / seeked; timeShift / timeShifted we need
   // to track stalling state between those events. To prevent tracking eg. when seeking in buffer we delay it.
   private stallTrackingTimout: Timeout = new Timeout(ConvivaAnalytics.STALL_TRACKING_DELAY_MS, () => {
@@ -382,18 +381,9 @@ export class ConvivaAnalytics {
   };
 
   private onPlaying = (event: PlaybackEvent) => {
-    this.playbackStarted = true;
     this.debugLog('playing', event);
     this.updateSession();
     this.onPlaybackStateChanged(event);
-  };
-
-  // When the first ON_TIME_CHANGED event arrives, the loading phase is finished and actual playback has started
-  private onTimeChanged = (event: PlaybackEvent) => {
-    if (this.isValidSession() && !this.playbackStarted) {
-      // fallback for player versions <= 7.2 which do not support ON_PLAYING Event
-      this.onPlaying(event);
-    }
   };
 
   private onPlaybackFinished = (event: PlayerEventBase) => {
@@ -496,7 +486,6 @@ export class ConvivaAnalytics {
 
     playerEvents.add(this.events.Play, this.onPlay);
     playerEvents.add(this.events.Playing, this.onPlaying);
-    playerEvents.add(this.events.TimeChanged, this.onTimeChanged);
     playerEvents.add(this.events.Paused, this.onPlaybackStateChanged);
     playerEvents.add(this.events.StallStarted, this.onPlaybackStateChanged);
     playerEvents.add(this.events.StallEnded, this.onPlaybackStateChanged);

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -51,7 +51,6 @@ export class ConvivaAnalytics {
   private readonly handlers: PlayerEventWrapper;
   private config: ConvivaAnalyticsConfiguration;
   private readonly contentMetadataBuilder: ContentMetadataBuilder;
-  private sessionDataPopulated: boolean;
 
   private readonly systemFactory: Conviva.SystemFactory;
   private readonly client: Conviva.Client;
@@ -86,8 +85,6 @@ export class ConvivaAnalytics {
       console.error('Bitmovin Conviva integration must be instantiated before calling player.load()');
       return; // Cancel initialization
     }
-
-    this.sessionDataPopulated = false;
 
     this.player = player;
 
@@ -384,7 +381,6 @@ export class ConvivaAnalytics {
     this.client.releasePlayerStateManager(this.playerStateManager);
 
     this.sessionKey = Conviva.Client.NO_SESSION_KEY;
-    this.sessionDataPopulated = false;
     this.contentMetadataBuilder.reset();
   };
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -1,7 +1,7 @@
 type ContentMetadata = Conviva.ContentMetadata;
 import {
   AdBreak,
-  AdBreakEvent,
+  AdBreakEvent, AdEvent,
   ErrorEvent,
   PlaybackEvent,
   PlayerAPI,
@@ -454,6 +454,14 @@ export class ConvivaAnalytics {
     this.client.adEnd(this.sessionKey);
   };
 
+  private onAdSkipped = (event: AdEvent) => {
+    this.onCustomEvent(event);
+  };
+
+  private onAdError = (event: AdEvent) => {
+    this.onCustomEvent(event);
+  };
+
   private onSeek = (event: SeekEvent) => {
     if (!this.isValidSession()) {
       // Handle the case that the User seeks on the UI before play was triggered.
@@ -550,6 +558,8 @@ export class ConvivaAnalytics {
     playerEvents.add(this.events.CastStopped, this.onCustomEvent);
     playerEvents.add(this.events.AdBreakStarted, this.onAdBreakStarted);
     playerEvents.add(this.events.AdBreakFinished, this.onAdBreakFinished);
+    playerEvents.add(this.events.AdSkipped, this.onAdSkipped);
+    playerEvents.add(this.events.AdError, this.onAdError);
     playerEvents.add(this.events.SourceUnloaded, this.onSourceUnloaded);
     playerEvents.add(this.events.Error, this.onError);
     playerEvents.add(this.events.Destroy, this.onDestroy);

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -444,7 +444,7 @@ export class ConvivaAnalytics {
     }
 
     if (playerState) {
-      this.debugLog('[ ConvivaAnalytics ] report playback state', event);
+      this.debugLog('[ ConvivaAnalytics ] report playback state', playerState);
       this.playerStateManager.setPlayerState(playerState);
     }
   };

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -332,10 +332,10 @@ export class ConvivaAnalytics {
     this.contentMetadataBuilder.assetName = this.getAssetNameFromSource(source);
     this.contentMetadataBuilder.viewerId = source.viewerId || this.contentMetadataBuilder.viewerId;
     this.contentMetadataBuilder.custom = {
+      ...this.contentMetadataBuilder.custom,
       playerType: this.player.getPlayerType(),
       streamType: this.player.getStreamType(),
       vrContentType: source.vr && source.vr.contentType,
-      ...this.contentMetadataBuilder.custom,
     };
 
     this.contentMetadataBuilder.streamUrl = this.getUrlFromSource(source);


### PR DESCRIPTION
## Description
Some events changed in player v8 so we need to adapt those in the integration.

Changes which are covered in this PR:
- No stalling events during `play` / `playing`; `seek` / `seeked` and `timeshift` / `timeshifted`
- Workaround for wrong player event in case of a pre-roll ad (The `adbreakstarted` event is triggered before an `play`)
- Added `seek` and `timeshift` tracking again
- Remove outdated flag