### PR TITLE
Fix missing bitrate tracking on session initialization

### DIFF
--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -2,7 +2,7 @@
 import { PlayerEvent } from './PlayerEvent';
 import {
   AdBreakEvent, AdEvent, PlaybackEvent, ErrorEvent, PlayerAPI, PlayerEventBase, PlayerEventCallback, SeekEvent,
-  TimeShiftEvent,
+  TimeShiftEvent, VideoPlaybackQualityChangedEvent,
 } from 'bitmovin-player';
 
 declare const global: any;
@@ -76,6 +76,7 @@ export namespace MockHelper {
     const setPlayerState = jest.fn();
     const setPlayerSeekStart = jest.fn();
     const setPlayerSeekEnd = jest.fn();
+    const setBitrateKbps = jest.fn();
 
     const PlayerStateManagerClass = jest.fn().mockImplementation(() => ({
       setPlayerType: jest.fn(),
@@ -83,6 +84,7 @@ export namespace MockHelper {
       setPlayerState,
       setPlayerSeekStart,
       setPlayerSeekEnd,
+      setBitrateKbps,
     }));
 
     global.Conviva.PlayerStateManager = PlayerStateManagerClass;
@@ -164,6 +166,8 @@ interface EventEmitter {
   fireAdSkippedEvent(): void;
 
   fireAdErrorEvent(): void;
+
+  fireVideoPlaybackQualityChangedEvent(bitrate: number): void;
 }
 
 class PlayerEventHelper implements EventEmitter {
@@ -325,6 +329,25 @@ class PlayerEventHelper implements EventEmitter {
     this.fireEvent<PlayerEventBase>({
       timestamp: Date.now(),
       type: PlayerEvent.TimeShifted,
+    });
+  }
+
+  fireVideoPlaybackQualityChangedEvent(bitrate: number): void {
+    this.fireEvent<VideoPlaybackQualityChangedEvent>({
+      timestamp: Date.now(),
+      type: PlayerEvent.VideoPlaybackQualityChanged,
+      sourceQuality: {
+        id: '1',
+        bitrate: 250_000,
+        width: null,
+        height: null,
+      },
+      targetQuality: {
+        id: '2',
+        bitrate: bitrate,
+        width: null,
+        height: null,
+      },
     });
   }
 }

--- a/spec/tests/PlayerEvents.spec.ts
+++ b/spec/tests/PlayerEvents.spec.ts
@@ -292,6 +292,26 @@ describe('player event tests', () => {
     });
   });
 
+  describe('bitrate tracking', () => {
+    it('report bitrate on event', () => {
+      playerMock.eventEmitter.firePlayEvent();
+      playerMock.eventEmitter.firePlayingEvent();
+      playerMock.eventEmitter.fireVideoPlaybackQualityChangedEvent(2_400_000);
+
+      expect(playerStateMock.setBitrateKbps).toHaveBeenCalledWith(2_400);
+    });
+
+    describe('event order workaround', () => {
+      it('track current bitrate on session initialization', () => {
+        playerMock.eventEmitter.fireVideoPlaybackQualityChangedEvent(4_800_000);
+        playerMock.eventEmitter.firePlayEvent();
+        playerMock.eventEmitter.firePlayingEvent();
+
+        expect(playerStateMock.setBitrateKbps).toHaveBeenCalledWith(4_800);
+      });
+    });
+  });
+
   describe('ad event workarounds', () => {
     describe('event order in case of pre-roll ad', () => {
       it('track pre-roll ad', () => {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -59,11 +59,16 @@ export class ConvivaAnalytics {
    */
   private isAd: boolean;
 
-  // Attributes needed to workaround wrong event order in case of a pre-roll ad. (See #onAdBreakStarted for more info)
+  /**
+   * Attributes needed to workaround wrong event order in case of a pre-roll ad.
+   * See {@link onAdBreakStarted} for more info
+   */
   private adBreakStartedToFire: AdBreakEvent;
 
-  // Needed to workaround wrong event order in case of a video-playback-quality-change event. (See
-  // #onVideoQualityChanged for more info)
+  /**
+   * Needed to workaround wrong event order in case of a video-playback-quality-change event.
+   * See {@link onVideoQualityChanged} for more info
+   */
   private lastSeenBitrate: number;
 
   // Since there are no stall events during play / playing; seek / seeked; timeShift / timeShifted we need


### PR DESCRIPTION
## Description
Since the first `videoPlaybackQualityChanged` event gets fired before the playback ever started the event can't be tracked 'cause no conviva tracking session is open at that point.

If the `videoPlaybackQuality` never changes again we never report a bitrate. To fix this issue (and improve) the bitrate will be remembered and set on session initialization.

## Tests
- Tests about bitrate tracking are added