### PR TITLE
Fix issue that reported values for seek events need to be integer values

### DIFF
--- a/spec/tests/PlayerEvents.spec.ts
+++ b/spec/tests/PlayerEvents.spec.ts
@@ -102,17 +102,14 @@ describe('player event tests', () => {
 
           it('delayed after seek', () => {
             playerMock.eventEmitter.fireSeekEvent();
-            // expect(playerStateMock.setPlayerState).toHaveBeenCalledWith(Conviva.PlayerStateManager.PlayerState.BUFFERING);
           });
 
           it('delayed after timeshift', () => {
             playerMock.eventEmitter.fireTimeShiftEvent();
-            // expect(playerStateMock.setPlayerState).toHaveBeenCalledWith(Conviva.PlayerStateManager.PlayerState.BUFFERING);
           });
 
           it('right after stall started', () => {
             playerMock.eventEmitter.fireStallStartedEvent();
-            // expect(playerStateMock.setPlayerState).toHaveBeenCalledWith(Conviva.PlayerStateManager.PlayerState.BUFFERING);
           });
 
           afterEach((done: any) => {
@@ -205,7 +202,7 @@ describe('player event tests', () => {
 
       describe('track seek start', () => {
         it('on seek', () => {
-          playerMock.eventEmitter.fireSeekEvent(50);
+          playerMock.eventEmitter.fireSeekEvent(50.145);
           expect(playerStateMock.setPlayerSeekStart).toHaveBeenCalledTimes(1);
           expect(playerStateMock.setPlayerSeekStart).toHaveBeenCalledWith(50);
         });

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -620,7 +620,7 @@ export class ConvivaAnalytics {
   };
 
   private trackSeekStart(target: number) {
-    this.playerStateManager.setPlayerSeekStart(target);
+    this.playerStateManager.setPlayerSeekStart(Math.round(target));
   }
 
   private trackSeekEnd() {


### PR DESCRIPTION
## Description
Values reported to conviva via seek tracking api need to be integer values.

## Fix
Round float values to integers.

## Tests
Seek tests adapted.