### PR TITLE
Remove outdated configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,7 @@ The recommended version of the Conviva SDK is 2.146.0.36444.** See [CHANGELOG](C
     });
     ```
 
-4. Add optional properties to the player's source configuration object to improve analytics data:
-    ```js
-    {
-      title: 'Art of Motion',
-      dash: '//bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
-
-      // Conviva Analytics properties
-      viewerId: 'uniqueViewerIdThatOverridesTheConvivaAnalyticsConfig',
-      contentId: 'uniqueContentId',
-    }
-    ```
-
-5. Release the instance by calling `conviva.release()` before destroying the player by calling `player.destroy()`
+4. Release the instance by calling `conviva.release()` before destroying the player by calling `player.destroy()`
  
 ### Advanced Usage
 
@@ -83,6 +71,7 @@ If you want to override some content metadata attributes you can do so by adding
 ```js
 let metadataOverrides = {
   applicationName: 'App Name',
+  viewerId: 'uniqueViewerId',
   custom: {
     customTag: 'customValue',
   },

--- a/example/index.html
+++ b/example/index.html
@@ -51,9 +51,12 @@
     var conviva = new bitmovin.player.analytics.ConvivaAnalytics(player, 'CUSTOMER_KEY', {
       debugLoggingEnabled: true,
       gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // TOUCHSTONE_SERVICE_URL for testing
+    });
+
+    conviva.updateContentMetadata({
       applicationName: 'Bitmovin Player Conviva Analytics Integration Test Page',
       viewerId: 'uniqueViewerId',
-      customTags: {
+      custom: {
         appVersion: '1.0',
         contentId: 'someContentId',
         playerVendor: 'bitmovin',

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -30,11 +30,6 @@ export interface EventAttributes {
   [key: string]: string;
 }
 
-export interface ConvivaSourceConfig extends SourceConfig {
-  viewerId?: string;
-  contentId?: string;
-}
-
 export class ConvivaAnalytics {
 
   private static readonly VERSION: string = '{{VERSION}}';
@@ -272,7 +267,7 @@ export class ConvivaAnalytics {
     }
   }
 
-  private getUrlFromSource(source: ConvivaSourceConfig): string {
+  private getUrlFromSource(source: SourceConfig): string {
     switch (this.player.getStreamType()) {
       case 'dash':
         return source.dash;
@@ -346,7 +341,7 @@ export class ConvivaAnalytics {
       integrationVersion: ConvivaAnalytics.VERSION,
     };
 
-    const source = this.player.getSource() as ConvivaSourceConfig;
+    const source = this.player.getSource();
 
     // This could be called before we got a source
     if (source) {
@@ -354,9 +349,9 @@ export class ConvivaAnalytics {
     }
   }
 
-  private buildSourceRelatedMetadata(source: ConvivaSourceConfig) {
+  private buildSourceRelatedMetadata(source: SourceConfig) {
     this.contentMetadataBuilder.assetName = this.getAssetNameFromSource(source);
-    this.contentMetadataBuilder.viewerId = source.viewerId || this.contentMetadataBuilder.viewerId;
+    this.contentMetadataBuilder.viewerId = this.contentMetadataBuilder.viewerId;
     this.contentMetadataBuilder.custom = {
       ...this.contentMetadataBuilder.custom,
       playerType: this.player.getPlayerType(),
@@ -375,21 +370,16 @@ export class ConvivaAnalytics {
     this.client.updateContentMetadata(this.sessionKey, this.contentMetadataBuilder.build());
   }
 
-  private getAssetNameFromSource(source: ConvivaSourceConfig): string {
+  private getAssetNameFromSource(source: SourceConfig): string {
     let assetName;
 
-    const assetId = source.contentId ? `[${source.contentId}]` : undefined;
     const assetTitle = source.title;
-
-    if (assetId && assetTitle) {
-      assetName = `${assetId} ${assetTitle}`;
-    } else if (assetId && !assetTitle) {
-      assetName = assetId;
-    } else if (assetTitle && !assetId) {
+    if (assetTitle) {
       assetName = assetTitle;
     } else {
-      assetName = 'Untitled (no source.title/source.contentId set)';
+      assetName = 'Untitled (no source.title set)';
     }
+
     return assetName;
   }
 


### PR DESCRIPTION
## Description
When we introduced a way to configure content metadata in a different way we forgot about the existing way. This PR will remove the legacy way of setting some content metadata.

_The changelog entry already exists_

## Tests
No tests needed to be added.