### PR TITLE
Add npmignore file to remove files from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-!dist
 .idea
 spec
 jest.config.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+!dist
+.idea
+spec
+jest.config.js
+example
+.travis.yml
+webpack.*.js


### PR DESCRIPTION
## Description
This will remove some unnecessary files from the package.

Also it will ensure that the `dist` folder is included when publishing. It would be ignored because it is ignored in the `.gitignore` file which is used per default.