### PR TITLE
Example on how to use the integration on chrome cast

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,6 +1,1 @@
-*
-!.gitignore
-!README.md
-!index.html
-!script.js
-!style.css
+conviva-core-sdk.min.js

--- a/example/chromecast/receiverApp.html
+++ b/example/chromecast/receiverApp.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+
+    <style>
+        body {
+            margin: 0;
+            background-color: black;
+            font-size: 14pt;
+        }
+
+        #player-wrapper {
+            height: 100%;
+            width: 100%;
+            position: fixed;
+        }
+
+        #app-status-overlay {
+            position: fixed;
+            left: 0;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+            background-color: black;
+            display: table;
+        }
+
+        #app-status-overlay-loading {
+            display: table-cell;
+            text-align: center;
+            vertical-align: middle;
+        }
+
+        @keyframes app-status-overlay-loading-dot {
+            0% {
+                opacity: 1;
+            }
+            25% {
+                opacity: 0;
+            }
+            50% {
+                opacity: 0;
+            }
+            75% {
+                opacity: 1;
+            }
+            100% {
+                opacity: 1;
+            }
+        }
+
+        .app-status-overlay-loading-dot {
+            display: inline-block;
+            width: 2em;
+            height: 2em;
+            border-radius: 50%;
+            background-color: #777;
+            margin: 0.3em;
+            animation: app-status-overlay-loading-dot 4s ease-in infinite;
+        }
+
+        .app-status-overlay-loading-dot:nth-child(1) {
+            animation-delay: .25s;
+        }
+
+        .app-status-overlay-loading-dot:nth-child(2) {
+            animation-delay: .5s;
+        }
+
+        .app-status-overlay-loading-dot:nth-child(3) {
+            animation-delay: .75s;
+        }
+    </style>
+</head>
+<body>
+<div id="player-wrapper"></div>
+<div id="app-status-overlay">
+    <div id="app-status-overlay-loading">
+        <div class="app-status-overlay-loading-dot"></div>
+        <div class="app-status-overlay-loading-dot"></div>
+        <div class="app-status-overlay-loading-dot"></div>
+    </div>
+</div>
+
+<script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
+<script src="../conviva-core-sdk.min.js"></script>
+<script src="../dist/bitmovin-player-analytics-conviva.js"></script>
+
+<link rel="stylesheet" href="https://cdn.bitmovin.com/player/web/8/bitmovinplayer-ui.css">
+<script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer-ui.js"></script>
+
+<script type="text/javascript" src="//www.gstatic.com/cast/sdk/libs/receiver/2.0.0/cast_receiver.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.2/require.js"
+        integrity="sha256-uvyqD81XGEqlTzEGkl+5L73IUlWTXtdLhfnUG5n3FbE="
+        crossorigin="anonymous"></script>
+<script type="text/javascript"
+        src="https://cdn.bitmovin.com/player/cast/8.1.0/bitmovinplayer-remotereceiver.js"></script>
+
+<script type="text/javascript">
+
+  // Hide app loading overlay
+  const hideStatusOverlay = () => {
+    document.getElementById('app-status-overlay').style.display = 'none';
+  };
+
+  window.onload = () => {
+    // Bitmovin Player configuration properties
+    const conf = {
+      key: 'YOUR-PLAYER-KEY',
+      tweaks: {
+        max_buffer_level: 20,
+      },
+      events: {},
+      ui: false,
+    };
+
+    // Instantiate a Bitmovin player
+    const player = new bitmovin.player.Player(document.getElementById('player-wrapper'), conf);
+    const convivaAnalytics = new bitmovin.player.analytics.ConvivaAnalytics(player, 'CUSTOMER_KEY', {
+      debugLoggingEnabled: true,
+      gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // TOUCHSTONE_SERVICE_URL for testing
+    });
+
+    convivaAnalytics.updateContentMetadata({
+      custom: {
+        runningOnChromeCast: 'true',
+      },
+    });
+
+    // Hide loading overlay when a source is loaded
+    player.on(bitmovin.player.PlayerEvent.SourceLoaded, hideStatusOverlay);
+
+    // Hide overlay when an error happens (avoids hidden errors during startup)
+    player.on(bitmovin.player.PlayerEvent.Error, hideStatusOverlay);
+    player.on(bitmovin.player.PlayerEvent.CastStopped, () => {
+      console.log('[log] stopped on receiver');
+    });
+
+    // Handler that takes properties from the remotecontrol.customReceiverConfig configuration for use within the receiver
+    require(['src/remotecontrol/GoogleCastRemoteControlReceiver'], (gcr) => {
+      const googleCastRemoteControlReceiver = new gcr.GoogleCastRemoteControlReceiver(player);
+
+      googleCastRemoteControlReceiver.setCastMetadataListener((metadata) => {
+        switch (metadata.type) {
+          case 'customReceiverConfig':
+            const customReceiverConfig = metadata.data;
+            if (customReceiverConfig.receiverStylesheetUrl != null) {
+              const head = document.getElementsByTagName('head')[0];
+              const link = document.createElement('link');
+              link.rel = 'stylesheet';
+              link.type = 'text/css';
+              link.href = customReceiverConfig.receiverStylesheetUrl;
+              head.appendChild(link);
+            }
+            break;
+        }
+      });
+
+      // The session should be closed as soon as the user presses the disconnect button. Currently the player doesn't
+      // notify the receiver app when this happens and just shutdown the cast manager.
+      // Therefore we need to listen on the onShutdown callback of the CastReceiverManager and end the session manually
+      // here.
+      cast.receiver.CastReceiverManager.getInstance().onShutdown = () => {
+        convivaAnalytics.endSession();
+      }
+    });
+
+    // Load the built-in Bitmovin Cast Receiver UI
+    const uimanager = bitmovin.playerui.UIFactory.buildDefaultCastReceiverUI(player);
+  }
+</script>
+</body>
+</html>

--- a/example/chromecast/receiverApp.html
+++ b/example/chromecast/receiverApp.html
@@ -139,10 +139,10 @@
       console.log('[log] stopped on receiver');
     });
 
-    // Handler that takes properties from the remotecontrol.customReceiverConfig configuration for use within the receiver
     require(['src/remotecontrol/GoogleCastRemoteControlReceiver'], (gcr) => {
       const googleCastRemoteControlReceiver = new gcr.GoogleCastRemoteControlReceiver(player);
 
+      // Handler that takes properties from the remotecontrol.customReceiverConfig configuration for use within the receiver
       googleCastRemoteControlReceiver.setCastMetadataListener((metadata) => {
         switch (metadata.type) {
           case 'customReceiverConfig':

--- a/example/index.html
+++ b/example/index.html
@@ -6,10 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitmovin Player Analytics Conviva Integration</title>
     <style>
-      figure {
-        margin: 0;
-        padding: 0;
-      }
       .container {
         color: white;
         text-align: center;

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -123,6 +123,7 @@ export namespace MockHelper {
         }),
         isPlaying: jest.fn(),
         isPaused: jest.fn(),
+        isCasting: jest.fn(),
         getPlayerType: jest.fn(),
         getStreamType: jest.fn(() => 'hls'),
 
@@ -184,6 +185,8 @@ interface EventEmitter {
   fireVideoPlaybackQualityChangedEvent(bitrate: number): void;
 
   fireCastStartedEvent(resuming?: boolean): void;
+
+  fireCastWaitingForDevice(resuming?: boolean): void;
 
   fireCastStoppedEvent(): void;
 }
@@ -406,6 +409,15 @@ class PlayerEventHelper implements EventEmitter {
     this.fireEvent<PlayerEventBase>({
       timestamp: Date.now(),
       type: PlayerEvent.CastStopped,
+    });
+  }
+
+  fireCastWaitingForDevice(resuming: boolean = false): void {
+    this.fireEvent<CastStartedEvent>({
+      timestamp: Date.now(),
+      type: PlayerEvent.CastWaitingForDevice,
+      deviceName: 'MyCastDevice',
+      resuming: false,
     });
   }
 }

--- a/spec/tests/Casting.spec.ts
+++ b/spec/tests/Casting.spec.ts
@@ -35,7 +35,7 @@ describe('casting', () => {
 
     describe('when cast started', () => {
       it('session gets closed', () => {
-        playerMock.eventEmitter.fireCastStartedEvent();
+        playerMock.eventEmitter.fireCastWaitingForDevice();
 
         expect(clientMock.cleanupSession).toHaveBeenCalledTimes(1);
       });
@@ -44,7 +44,7 @@ describe('casting', () => {
     describe('when cast stopped', () => {
       beforeEach(() => {
         (clientMock.createSession as jest.Mock).mockClear();
-        playerMock.eventEmitter.fireCastStartedEvent();
+        playerMock.eventEmitter.fireCastWaitingForDevice();
       });
 
       describe('and the player is playing', () => {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -689,7 +689,8 @@ export class ConvivaAnalytics {
     playerEvents.add(this.events.Muted, this.onCustomEvent);
     playerEvents.add(this.events.Unmuted, this.onCustomEvent);
     playerEvents.add(this.events.ViewModeChanged, this.onCustomEvent);
-    playerEvents.add(this.events.CastStarted, this.onCastStarted);
+    // We need to wait until the user chose a device for closing the session on the sender app
+    playerEvents.add(this.events.CastWaitingForDevice, this.onCastInitiated);
     playerEvents.add(this.events.CastStopped, this.onCastStopped);
     playerEvents.add(this.events.AdBreakStarted, this.onAdBreakStarted);
     playerEvents.add(this.events.AdBreakFinished, this.onAdBreakFinished);
@@ -743,7 +744,7 @@ export class ConvivaAnalytics {
     this.onAdFinished(event);
   };
 
-  private onCastStarted = (event: CastStartedEvent) => {
+  private onCastInitiated = (event: CastStartedEvent) => {
     this.onCustomEvent(event);
     this.internalEndSession(event);
 

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,6 +6,7 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
+    host: '0.0.0.0',
     publicPath: '/dist/',
     contentBase: path.resolve(__dirname, 'example'),
     watchContentBase: true


### PR DESCRIPTION
## Description
Currently we have no example on how to use the integration on a chrome cast device

## Fix
- This PR adds an example of how to use the integration within a custom cast receiver app.
- Stop the tracking session from the sender app on `CastWaitingForDevice` as this is the event when the user selected a device.

## Tests
Adopted to the new event.

## Manual Tests
- Create a custom receiver app and use the new `receiverApp.html` file
- Ensure that the session of the sender app gets closed and a new one gets created from the receiver app.