### PR TITLE
Content metadata support on chromecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Chromecast support 
+- Update content metadata attributes on the receiver directly via the sender instance of the integration
 
 ## [3.0.0]
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ The recommended version of the Conviva SDK is 2.146.0.36444.** See [CHANGELOG](C
  
 ### Advanced Usage
 
+#### Chromecast support
+
+_If you are not familiar with how to add chromecast support we suggest to look at our [public sample](https://github.com/bitmovin/bitmovin-player-web-samples/tree/master/castReceiver) first._
+
+If you would like to add the conviva integration to your chromecast you can have a look at our [custom receiver app example](./example/chromecast/receiverApp.html) with conviva integration.
+
+As the player itself does not notify listeners on the receiver app itself if the session will be stopped you need to add a listener to the `onShutdown` and end the session manually.
+
+For doing so you need to add following lines:
+
+```js
+cast.receiver.CastReceiverManager.getInstance().onShutdown = () => {
+  convivaAnalytics.endSession();
+}
+```
+
+If you are using the content metadata overriding feature you will have to add following line within the `CastMetadataListener` callback:
+
+```js
+convivaAnalytics.handleCastMetadataEvent(metadata);
+```
+
+This will ensure that all your content metadata attributes are also present in the session of the receiver app.
+It will also enable that you can use `updateContentMetadata` on the sender and it will be propagated to the receiver app.
+
+
 #### VPF tracking
 
 If you would like to track custom VPF (Video Playback Failures) events when no actual player error happens (e.g. 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ _If you are not familiar with how to add chromecast support we suggest to look a
 
 If you would like to add the conviva integration to your chromecast you can have a look at our [custom receiver app example](./example/chromecast/receiverApp.html) with conviva integration.
 
-As the player itself does not notify listeners on the receiver app itself if the session will be stopped you need to add a listener to the `onShutdown` and end the session manually.
+As the player does not notify listeners on the receiver app itself if the session will be stopped you need to add a listener to the `onShutdown` and end the session manually.
 
-For doing so you need to add following lines:
+In order to do so you need to add following lines:
 
 ```js
 cast.receiver.CastReceiverManager.getInstance().onShutdown = () => {
@@ -67,14 +67,14 @@ cast.receiver.CastReceiverManager.getInstance().onShutdown = () => {
 }
 ```
 
-If you are using the content metadata overriding feature you will have to add following line within the `CastMetadataListener` callback:
+If you are using the content metadata overriding feature you will have to add the following line within the `CastMetadataListener` callback:
 
 ```js
 convivaAnalytics.handleCastMetadataEvent(metadata);
 ```
 
 This will ensure that all your content metadata attributes are also present in the session of the receiver app.
-It will also enable that you can use `updateContentMetadata` on the sender and it will be propagated to the receiver app.
+It will also enable you to use `updateContentMetadata` on the sender and it will be propagated to the receiver app.
 
 
 #### VPF tracking

--- a/example/chromecast/receiverApp.html
+++ b/example/chromecast/receiverApp.html
@@ -144,6 +144,11 @@
 
       // Handler that takes properties from the remotecontrol.customReceiverConfig configuration for use within the receiver
       googleCastRemoteControlReceiver.setCastMetadataListener((metadata) => {
+        // This will handle the communication between the instance of conviva analytics on the sender and the receiver
+        // app. The Player itself doesn't provide a communication out of the box so we need to handle this inside the
+        // setCastMetadataListener here. (The type and the data of the metadata object is handled within the integration)
+        convivaAnalytics.handleCastMetadataEvent(metadata);
+
         switch (metadata.type) {
           case 'customReceiverConfig':
             const customReceiverConfig = metadata.data;

--- a/example/index.html
+++ b/example/index.html
@@ -88,7 +88,11 @@
           level: 'debug'
         },
         events: {},
-        advertising: {}
+        advertising: {},
+        remotecontrol: {
+          receiverApplicationId: 'FE832A8F', // Replace with your application id
+          type: 'googlecast',
+        }
       };
     }
 

--- a/example/index.html
+++ b/example/index.html
@@ -28,7 +28,7 @@
         box-shadow: 0 0 30px rgba(0,0,0,0.7);
       }
     </style>
-    <script src="https://cdn.bitmovin.com/player/web/staging/8/bitmovinplayer.js"></script>
+    <script src="//cdn.bitmovin.com/player/web/8.6.0/bitmovinplayer.js"></script>
     <script src="./conviva-core-sdk.min.js"></script>
     <script src="./dist/bitmovin-player-analytics-conviva.js"></script>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -900,9 +900,9 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.3.0-rc2",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.3.0-rc2.tgz",
-      "integrity": "sha512-hwwG2a4RVoKSBUOlTHD3fF0mITmsj5KD1vMoujouHehYmbiaC3wRLu4OEsjRUut02EVcQTGP8rchw07qFvjrNA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.6.0.tgz",
+      "integrity": "sha512-wF0xIZlEl0fP3tHOFEwKnNFXmfsGr+8yMIpYAAh3QIMYMBD3/MG+uvoKkiPVhykentyJu4vXC7YlyCo6ozGnwA==",
       "dev": true
     },
     "bitmovin-player-ui": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^24.0.1",
-    "bitmovin-player": "^8.3.0-rc2",
+    "bitmovin-player": "^8.6.0",
     "bitmovin-player-ui": "^3.3.1",
     "create-file-webpack": "^1.0.2",
     "jest": "^24.1.0",

--- a/spec/tests/Casting.spec.ts
+++ b/spec/tests/Casting.spec.ts
@@ -1,5 +1,8 @@
 import { ConvivaAnalytics } from '../../src/ts';
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
+import { CONTENT_SESSION_KEY } from '../helper/TestsHelper';
+
+declare const global: any;
 
 describe('casting', () => {
   let convivaAnalytics: ConvivaAnalytics;
@@ -66,6 +69,76 @@ describe('casting', () => {
           playerMock.eventEmitter.firePlayEvent();
           expect(clientMock.createSession).toHaveBeenCalledTimes(1);
         });
+      });
+    });
+  });
+
+  // TODO: consider moving to ContentMetadata specs
+  describe('and content metadata handling', () => {
+    let receiverConvivaAnalytics: ConvivaAnalytics;
+    let receiverPlayerMock: TestingPlayerAPI;
+    let receiverConvivaAnalyticsClientMock: Conviva.Client;
+
+    beforeEach(() => {
+      receiverPlayerMock = MockHelper.getPlayerMock();
+
+      receiverConvivaAnalytics = new ConvivaAnalytics(receiverPlayerMock, 'TEST-KEY');
+      // Find more information why we need the private client in MockHelper.ts#getConvivaClientMock
+      receiverConvivaAnalyticsClientMock = (receiverConvivaAnalytics as any).client;
+    });
+
+    const startPlayback = () => {
+      playerMock.eventEmitter.firePlayEvent();
+      playerMock.eventEmitter.firePlayingEvent();
+    };
+
+    const mockPlayerCastModule = () => {
+      // Mock cast player implementation
+      MockHelper.mockCastPlayerModule();
+      // This actually mocks something the customer needs to do
+      global.gcr.castMetadataListenerCallback = (metadata: any) => {
+        receiverConvivaAnalytics.handleCastMetadataEvent(metadata);
+      };
+    };
+
+    describe('propagates all content metadata to receiver instance', () => {
+      it('when cast started during playback', () => {
+        convivaAnalytics.updateContentMetadata({
+          custom: {
+            customTagForCastTest: 'With Value',
+          },
+        });
+
+        startPlayback();
+        mockPlayerCastModule();
+
+        playerMock.eventEmitter.fireCastStartedEvent();
+
+        expect(receiverConvivaAnalyticsClientMock.updateContentMetadata).toHaveBeenNthCalledWith(
+          1,
+          CONTENT_SESSION_KEY,
+          expect.objectContaining({
+            custom: expect.objectContaining({
+              customTagForCastTest: 'With Value',
+            }),
+          }),
+        );
+      });
+
+      it('when calling update content metadata on the sender instance', () => {
+        startPlayback();
+        mockPlayerCastModule();
+
+        playerMock.eventEmitter.fireCastStartedEvent();
+
+        convivaAnalytics.updateContentMetadata({ encodedFrameRate: 260 });
+        expect(receiverConvivaAnalyticsClientMock.updateContentMetadata).toHaveBeenNthCalledWith(
+          1,
+          CONTENT_SESSION_KEY,
+          expect.objectContaining({
+            encodedFrameRate: 260,
+          }),
+        );
       });
     });
   });

--- a/src/ts/ContentMetadataBuilder.ts
+++ b/src/ts/ContentMetadataBuilder.ts
@@ -49,6 +49,10 @@ export class ContentMetadataBuilder {
     this.metadataOverrides = newValue;
   }
 
+  getOverrides(): Metadata {
+    return this.metadataOverrides;
+  }
+
   setPlaybackStarted(value: boolean) {
     this.playbackStarted = value;
   }

--- a/src/ts/ContentMetadataBuilder.ts
+++ b/src/ts/ContentMetadataBuilder.ts
@@ -46,7 +46,7 @@ export class ContentMetadataBuilder {
       );
     }
 
-    this.metadataOverrides = newValue;
+    this.metadataOverrides = { ...this.metadataOverrides, ...newValue };
   }
 
   getOverrides(): Metadata {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -486,7 +486,7 @@ export class ConvivaAnalytics {
     this.sessionKey = Conviva.Client.NO_SESSION_KEY;
     this.lastSeenBitrate = null;
 
-    // As the session could be continued after casting we can't reset the contentMetadataBuilder here as we would loose
+    // As the session could be continued after casting we can't reset the contentMetadataBuilder here as we would lose
     // content metadata attributes.
   };
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -448,7 +448,7 @@ export class ConvivaAnalytics {
 
   // This will propagate content metadata overrides to the conviva instance of the receiver app
   private propagateOverridesToReceiver(metadataOverrides?: Metadata) {
-    metadataOverrides = metadataOverrides ? metadataOverrides : this.contentMetadataBuilder.getOverrides();
+    metadataOverrides = metadataOverrides || this.contentMetadataBuilder.getOverrides();
 
     const metadataObject = {
       type: ConvivaAnalytics.CAST_METADATA_TYPE,

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -233,7 +233,7 @@ export class ConvivaAnalytics {
       this.propagateOverridesToReceiver(metadataOverrides);
     }
 
-    this.internalSetOverrides(metadataOverrides);
+    this.internalUpdateContentMetadata(metadataOverrides);
   }
 
   /**
@@ -289,7 +289,7 @@ export class ConvivaAnalytics {
    */
   public handleCastMetadataEvent(metadata: any): void {
     if (metadata.type === ConvivaAnalytics.CAST_METADATA_TYPE) {
-      this.internalSetOverrides(metadata.metadata);
+      this.internalUpdateContentMetadata(metadata.metadata);
     }
   }
 
@@ -327,7 +327,7 @@ export class ConvivaAnalytics {
     }
   }
 
-  private internalSetOverrides(metadataOverrides: Metadata) {
+  private internalUpdateContentMetadata(metadataOverrides: Metadata) {
     this.contentMetadataBuilder.setOverrides(metadataOverrides);
 
     if (!this.isSessionActive()) {


### PR DESCRIPTION
## Description
Currently you have to update content metadata on the sender app as well as on the receiver app event the same values should be used.

## Solution
Introduce a proper way on how to send data from the sender app to the receiver app. This lead to the opportunity that the content metadata attributes just need to be set once and also can be set directly via the sender app.

## Changes
- Close the cast session on the sender app immediately when the user clicks on a cast device instead of the `CastStarted` event (Unreleased)

## Tests
New tests added