### PR TITLE
Do not initialize session internally when endSession is called externally

### DIFF
--- a/spec/tests/ExternalSessionManaging.spec.ts
+++ b/spec/tests/ExternalSessionManaging.spec.ts
@@ -74,4 +74,20 @@ describe('externally session managing', () => {
       expect((clientMock.createSession as jest.Mock).mock.calls[0][0].assetName).toEqual('MyTitle');
     });
   });
+
+  describe('external endsession is called', () => {
+      it('should not initialize session when player events fire after being ended externally', () => {
+          playerMock.eventEmitter.firePlayEvent();
+
+          expect(clientMock.createSession).toHaveBeenCalled();
+
+          convivaAnalytics.endSession();
+
+          expect(clientMock.cleanupSession).toHaveBeenCalled();
+
+          playerMock.eventEmitter.firePlayEvent();
+
+          expect(clientMock.createSession).toHaveBeenCalledTimes(1);
+      });
+  });
 });

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -186,7 +186,9 @@ export class ConvivaAnalytics {
    * Ends the current conviva tracking session.
    * Results in a no-opt if there is no active session.
    *
-   * Warning: The integration can only be validated without external session managing. So when using this method we can
+   * Warning: Sessions will no longer be created automatically after this method has been called.
+   *
+   * The integration can only be validated without external session managing. So when using this method we can
    * no longer ensure that the session is managed at the correct time.
    */
   public endSession(): void {


### PR DESCRIPTION
…ally

If a developer chooses to end the Conviva session explicitly via the `endSession()` call, we should not re-initialize the session when certain player events fire and instead should only allow the external caller to re-initialize the session via `initializeSession` at their discretion.