### PR TITLE
Change updateContentMetadata loglevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Chromecast support 
 - Update content metadata attributes on the receiver directly via the sender instance of the integration
 - Changelog entry about NPM usage
+- Change loglevel of message when `updateContentMetadata` is invoke before a session has been started
+- `endSession` will now prevent a new session from being initialized via internal event handling
 
 ## [3.0.0]
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -342,8 +342,8 @@ export class ConvivaAnalytics {
 
     if (!this.isSessionActive()) {
       this.logger.consoleLog(
-        '[ ConvivaAnalytics ] no active session; Don\'t propagate content metadata to conviva.',
-        Conviva.SystemSettings.LogLevel.WARNING,
+        '[ ConvivaAnalytics ] no active session. Content metadata will be propagated to Conviva on session initialization.',
+        Conviva.SystemSettings.LogLevel.DEBUG,
       );
       return;
     }


### PR DESCRIPTION
The "WARNING" level of the message when the session is not active can throw off developers as it implies something may not be setup correctly.

Since we are still updating the content metadata but wait until session initialization, changing the log level to "DEBUG" seems more appropriate.