### PR TITLE
Add a ConvivaAnalyticsConfiguration option to set DeviceCategory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update content metadata attributes on the receiver directly via the sender instance of the integration
 - Changelog entry about NPM usage
 - Change loglevel of message when `updateContentMetadata` is invoke before a session has been started
+- Added a configuration option to set the Conviva Device Category. 
 
 ## [3.0.2]
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Build the JS file by running `npm run build`
             const conviva = new ConvivaAnalytics(player, 'CUSTOMER_KEY', {
               debugLoggingEnabled: true, // optional
               gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // optional, TOUCHSTONE_SERVICE_URL for testing
+              deviceCategory: Conviva.Client.DeviceCategory.WEB // optional, (default: WEB)
             });
             
             var sourceConfig = {

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -93,6 +93,10 @@ export namespace MockHelper {
       SERVER_SIDE: 'Server Side',
     };
 
+    global.Conviva.Client.DeviceCategory = {
+      WEB: 'WEB'
+    }
+
     return new global.Conviva.Client();
   }
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -21,6 +21,7 @@ import { BasicAdTrackingPlugin } from './BasicAdTrackingPlugin';
 import { BitrateHelper } from './helper/BitrateHelper';
 
 import { ArrayUtils } from 'bitmovin-player-ui/dist/js/framework/arrayutils';
+import { DeviceMetadata } from './DeviceMetadata';
 
 type Player = PlayerAPI;
 
@@ -139,12 +140,16 @@ export class ConvivaAnalytics {
     this.logger = new Html5Logging();
     this.sessionKey = Conviva.Client.NO_SESSION_KEY;
 
+    const deviceMetadata: DeviceMetadata = {
+      deviceCategory: this.config.deviceCategory,
+    };
+
     const systemInterface = new Conviva.SystemInterface(
       new Html5Time(),
       new Html5Timer(),
       new Html5Http(),
       new Html5Storage(),
-      new Html5Metadata(this.config.deviceCategory),
+      new Html5Metadata(deviceMetadata),
       this.logger,
     );
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -21,7 +21,7 @@ import { BasicAdTrackingPlugin } from './BasicAdTrackingPlugin';
 import { BitrateHelper } from './helper/BitrateHelper';
 
 import { ArrayUtils } from 'bitmovin-player-ui/dist/js/framework/arrayutils';
-import { DeviceMetadata } from './DeviceMetadata';
+import { DeviceMetadata } from './Html5Metadata';
 
 type Player = PlayerAPI;
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -134,6 +134,7 @@ export class ConvivaAnalytics {
 
     // Set default config values
     this.config.debugLoggingEnabled = this.config.debugLoggingEnabled || false;
+    this.config.deviceCategory = this.config.deviceCategory || Conviva.Client.DeviceCategory.WEB;
 
     this.logger = new Html5Logging();
     this.sessionKey = Conviva.Client.NO_SESSION_KEY;

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -56,7 +56,7 @@ export interface ConvivaAnalyticsConfiguration {
   adTrackingMode?: AdTrackingMode;
 
   /**
-   * Option to set the Conviva Device Category, which is used to assist with  
+   * Option to set the Conviva Device Category, which is used to assist with
    * user agent string parsing by the Conviva SDK. (default: WEB)
    */
   deviceCategory?: Conviva.Client.DeviceCategory;

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -134,7 +134,6 @@ export class ConvivaAnalytics {
 
     // Set default config values
     this.config.debugLoggingEnabled = this.config.debugLoggingEnabled || false;
-    this.config.deviceCategory = this.config.deviceCategory || Conviva.Client.DeviceCategory.WEB;
 
     this.logger = new Html5Logging();
     this.sessionKey = Conviva.Client.NO_SESSION_KEY;

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -54,6 +54,12 @@ export interface ConvivaAnalyticsConfiguration {
    * (Also includes behaviour of AdBreaks mode).
    */
   adTrackingMode?: AdTrackingMode;
+
+  /**
+   * Option to set the Conviva Device Category, which is used to assist with  
+   * user agent string parsing by the Conviva SDK. (default: WEB)
+   */
+  deviceCategory?: Conviva.Client.DeviceCategory;
 }
 
 export interface EventAttributes {
@@ -128,6 +134,7 @@ export class ConvivaAnalytics {
 
     // Set default config values
     this.config.debugLoggingEnabled = this.config.debugLoggingEnabled || false;
+    this.config.deviceCategory = this.config.deviceCategory || Conviva.Client.DeviceCategory.WEB;
 
     this.logger = new Html5Logging();
     this.sessionKey = Conviva.Client.NO_SESSION_KEY;
@@ -137,7 +144,7 @@ export class ConvivaAnalytics {
       new Html5Timer(),
       new Html5Http(),
       new Html5Storage(),
-      new Html5Metadata(),
+      new Html5Metadata(this.config.deviceCategory),
       this.logger,
     );
 

--- a/src/ts/DeviceMetadata.ts
+++ b/src/ts/DeviceMetadata.ts
@@ -1,4 +1,0 @@
-
-export interface DeviceMetadata {
-  deviceCategory: Conviva.Client.DeviceCategory;
-}

--- a/src/ts/DeviceMetadata.ts
+++ b/src/ts/DeviceMetadata.ts
@@ -1,0 +1,4 @@
+
+export interface DeviceMetadata {
+  deviceCategory: Conviva.Client.DeviceCategory;
+}

--- a/src/ts/Html5Metadata.ts
+++ b/src/ts/Html5Metadata.ts
@@ -1,10 +1,11 @@
 import Client = Conviva.Client;
+import { DeviceMetadata } from './DeviceMetadata';
 
 export class Html5Metadata implements Conviva.MetadataInterface {
-  deviceCategory?: Client.DeviceCategory;
+  metadata?: DeviceMetadata;
 
-  constructor(deviceCategory?: Client.DeviceCategory) {
-    this.deviceCategory = deviceCategory;
+  constructor(metadata?: DeviceMetadata) {
+    this.metadata = metadata;
   }
 
   // Relying on HTTP user agent string parsing on the Conviva Platform.
@@ -64,7 +65,7 @@ export class Html5Metadata implements Conviva.MetadataInterface {
 
   // Relying on HTTP user agent string parsing on the Conviva Platform.
   getDeviceCategory(): Conviva.Client.DeviceCategory {
-    return this.deviceCategory;
+    return this.metadata.deviceCategory;
   }
 
   public release(): void {

--- a/src/ts/Html5Metadata.ts
+++ b/src/ts/Html5Metadata.ts
@@ -1,10 +1,13 @@
 import Client = Conviva.Client;
-import { DeviceMetadata } from './DeviceMetadata';
+
+export interface DeviceMetadata {
+  deviceCategory: Conviva.Client.DeviceCategory;
+}
 
 export class Html5Metadata implements Conviva.MetadataInterface {
-  metadata?: DeviceMetadata;
+  metadata: DeviceMetadata;
 
-  constructor(metadata?: DeviceMetadata) {
+  constructor(metadata: DeviceMetadata) {
     this.metadata = metadata;
   }
 

--- a/src/ts/Html5Metadata.ts
+++ b/src/ts/Html5Metadata.ts
@@ -1,6 +1,11 @@
 import Client = Conviva.Client;
 
 export class Html5Metadata implements Conviva.MetadataInterface {
+  deviceCategory?: Client.DeviceCategory;
+
+  constructor(deviceCategory?: Client.DeviceCategory) {
+    this.deviceCategory = deviceCategory;
+  }
 
   // Relying on HTTP user agent string parsing on the Conviva Platform.
   public getBrowserName(): string | null {
@@ -59,7 +64,7 @@ export class Html5Metadata implements Conviva.MetadataInterface {
 
   // Relying on HTTP user agent string parsing on the Conviva Platform.
   getDeviceCategory(): Conviva.Client.DeviceCategory {
-    return null;
+    return this.deviceCategory;
   }
 
   public release(): void {

--- a/src/ts/Html5Metadata.ts
+++ b/src/ts/Html5Metadata.ts
@@ -64,7 +64,7 @@ export class Html5Metadata implements Conviva.MetadataInterface {
 
   // Relying on HTTP user agent string parsing on the Conviva Platform.
   getDeviceCategory(): Conviva.Client.DeviceCategory {
-    return this.deviceCategory;
+    return this.deviceCategory || Conviva.Client.DeviceCategory.WEB;
   }
 
   public release(): void {

--- a/src/ts/Html5Metadata.ts
+++ b/src/ts/Html5Metadata.ts
@@ -64,7 +64,7 @@ export class Html5Metadata implements Conviva.MetadataInterface {
 
   // Relying on HTTP user agent string parsing on the Conviva Platform.
   getDeviceCategory(): Conviva.Client.DeviceCategory {
-    return this.deviceCategory || Conviva.Client.DeviceCategory.WEB;
+    return this.deviceCategory;
   }
 
   public release(): void {


### PR DESCRIPTION
After going back and forth with Conviva we determined that the best approach to handling Device Category would be to allow an option for setting the category. This value will then be used within the Conviva SDK to influence their parsing of the user agent string.