### PR TITLE
Report playing state after ad break is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Develop
+
+### Fixed
+- Send playing event after an ad break has finished.
+
 ## [3.0.3]
 
+### Added
 - Added a configuration option to set the Conviva Device Category. 
 
 ## [3.0.2]

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -602,6 +602,7 @@ export class ConvivaAnalytics {
     }
 
     this.client.adEnd(this.sessionKey);
+    this.playerStateManager.setPlayerState(Conviva.PlayerStateManager.PlayerState.PLAYING);
   };
 
   private onAdSkipped = (event: AdEvent) => {


### PR DESCRIPTION
Small fix to send the playing state after we receive the `adBreakFinished` event﻿
