### PR TITLE
Use window.setInterval in Html5Timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Develop
+
+### Fixed
+- Prefer `window.setInterval()` in `Html5Timer.ts` instead of the NodeJS definition.
+
 ## [3.0.5]
 
 ### Fixed

--- a/src/ts/Html5Timer.ts
+++ b/src/ts/Html5Timer.ts
@@ -4,7 +4,7 @@ import TimerAction = Conviva.TimerAction;
 export class Html5Timer implements Conviva.TimerInterface {
 
   public createTimer(timerAction: TimerAction, intervalMs: number, actionName?: string | null): TimerCancelFunction {
-    let timerId = setInterval(timerAction, intervalMs);
+    let timerId = window.setInterval(timerAction, intervalMs);
     return (function() {
       if (timerId !== -1) {
         clearInterval(timerId);


### PR DESCRIPTION
After updating `webpack-dev-server` to 3.10.3, the NodeJS definition of `setInterval()` was being used in `Html5Timer.ts`, which has a `NodeJS.Timeout` return type. This changes to explicitly use window.setInterval(). 