### PR TITLE
fix: Remove redundant Conviva release calls in destroy method

### DIFF
--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -286,8 +286,6 @@ export class ConvivaAnalytics {
   private destroy(event?: PlayerEventBase): void {
     this.unregisterPlayerEvents();
     this.internalEndSession(event);
-    this.convivaVideoAnalytics.release();
-    Conviva.Analytics.release();
   }
 
   private debugLog(message?: any, ...optionalParams: any[]): void {


### PR DESCRIPTION
Both these resources are alreadt taken care of by the internalEndSession
call in the line above.