### PR TITLE
Removed clearing of metadata at playback completion

### DIFF
--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -555,7 +555,6 @@ export class ConvivaAnalytics {
     this.onPlaybackStateChanged(event);
     this.convivaVideoAnalytics.release();
     this.convivaVideoAnalytics = null;
-    this.resetContentMetadata();
   };
 
   private onVideoQualityChanged = (event: VideoQualityChangedEvent) => {


### PR DESCRIPTION
We removed content metadata reset from playback finished event. It will still reset out on source unload or when session end event is called. An alternative fix would be to call conviva.updateContentMetadata on the conviva object returned from the bitmovin player when a replay is replayed. Similar to how it is done in the index.html file initially.

ex:
conviva.updateContentMetadata({ applicationName: 'Bitmovin Player Conviva Analytics Integration Test Page', viewerId: 'uniqueViewerId', custom: { appVersion: '1.0', contentId: 'someContentId', playerVendor: 'bitmovin', playerVersion: player.version }, });