### PR TITLE
Adding possibility for application to override internally used custom metadata tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `bitmovin-player@^8.31.0` as peer dependency.
 - Possibility to set detailed Conviva Device Metadata via `ConvivaAnalyticsConfiguration.deviceMetadata`
-- Possibility to override values for internally set custom metdata keys streamType, playerType and vrContentType
+- Possibility to override values for internally set custom metdata keys `streamType`, `playerType` and `vrContentType`
 
 ### Deprecated
 - `ConvivaAnalyticsConfiguration.deviceCategory` field in favour of `ConvivaAnalyticsConfiguration.deviceMetadata.category` field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `bitmovin-player@^8.31.0` as peer dependency.
 - Possibility to set detailed Conviva Device Metadata via `ConvivaAnalyticsConfiguration.deviceMetadata`
+- Possibility to override values for internally set custom metdata keys streamType, playerType and vrContentType
 
 ### Deprecated
 - `ConvivaAnalyticsConfiguration.deviceCategory` field in favour of `ConvivaAnalyticsConfiguration.deviceMetadata.category` field

--- a/spec/tests/ContentMetadata.spec.ts
+++ b/spec/tests/ContentMetadata.spec.ts
@@ -1,5 +1,5 @@
 /// <reference path='../../src/ts/Conviva.d.ts'/>
-import { PlayerType } from 'bitmovin-player';
+import {PlayerType, StreamType, VRContentType} from 'bitmovin-player';
 import { ConvivaAnalytics } from '../../src/ts';
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 
@@ -34,12 +34,60 @@ describe('content metadata spec', () => {
       }));
     });
 
-    it('set player type in custom tags', () => {
+    it('default playerType in custom tags', () => {
       jest.spyOn(playerMock, 'getPlayerType').mockReturnValue(PlayerType.Native);
       playerMock.eventEmitter.firePlayEvent();
 
       expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
         playerType: 'native',
+      }));
+    });
+
+    it('default streamType in custom tags', () => {
+      jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
+      playerMock.eventEmitter.firePlayEvent();
+
+      expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
+        streamType: 'dash',
+      }));
+    });
+
+    it('default vrContentType in custom tags', () => {
+      playerMock.eventEmitter.firePlayEvent();
+
+      expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
+        vrContentType: undefined,
+      }));
+    });
+
+    it('override playerType in custom tags', () => {
+      jest.spyOn(playerMock, 'getPlayerType').mockReturnValue(PlayerType.Native);
+      jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
+      convivaAnalytics.updateContentMetadata({ custom: { myTag: 'withMyValue', playerType: PlayerType.Html5 }, assetName: 'MyAsset' });
+      playerMock.eventEmitter.firePlayEvent();
+
+      expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
+        playerType: PlayerType.Html5,
+        streamType: StreamType.Dash}));
+    });
+
+    it('override streamType in custom tags', () => {
+      jest.spyOn(playerMock, 'getPlayerType').mockReturnValue(PlayerType.Native);
+      jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
+      convivaAnalytics.updateContentMetadata({ custom: { myTag: 'withMyValue', streamType: 'dash_vod' }, assetName: 'MyAsset' });
+      playerMock.eventEmitter.firePlayEvent();
+
+      expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
+        playerType: PlayerType.Native,
+        streamType: 'dash_vod'}));
+    });
+
+    it('override vrContentType in custom tags', () => {
+      convivaAnalytics.updateContentMetadata({ custom: { myTag: 'withMyValue', vrContentType: VRContentType.Single }, assetName: 'MyAsset' });
+      playerMock.eventEmitter.firePlayEvent();
+
+      expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
+        vrContentType: VRContentType.Single,
       }));
     });
 

--- a/spec/tests/ContentMetadata.spec.ts
+++ b/spec/tests/ContentMetadata.spec.ts
@@ -1,5 +1,5 @@
 /// <reference path='../../src/ts/Conviva.d.ts'/>
-import {PlayerType, StreamType, VRContentType} from 'bitmovin-player';
+import { PlayerType, StreamType, VRContentType } from 'bitmovin-player';
 import { ConvivaAnalytics } from '../../src/ts';
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 
@@ -34,7 +34,7 @@ describe('content metadata spec', () => {
       }));
     });
 
-    it('default playerType in custom tags', () => {
+    it('sets the default playerType in custom tags', () => {
       jest.spyOn(playerMock, 'getPlayerType').mockReturnValue(PlayerType.Native);
       playerMock.eventEmitter.firePlayEvent();
 
@@ -43,7 +43,7 @@ describe('content metadata spec', () => {
       }));
     });
 
-    it('default streamType in custom tags', () => {
+    it('sets the default streamType in custom tags', () => {
       jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
       playerMock.eventEmitter.firePlayEvent();
 
@@ -52,7 +52,7 @@ describe('content metadata spec', () => {
       }));
     });
 
-    it('default vrContentType in custom tags', () => {
+    it('sets the default vrContentType in custom tags', () => {
       playerMock.eventEmitter.firePlayEvent();
 
       expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -63,7 +63,7 @@ describe('content metadata spec', () => {
     it('override playerType in custom tags', () => {
       jest.spyOn(playerMock, 'getPlayerType').mockReturnValue(PlayerType.Native);
       jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
-      convivaAnalytics.updateContentMetadata({ custom: { myTag: 'withMyValue', playerType: PlayerType.Html5 }, assetName: 'MyAsset' });
+      convivaAnalytics.updateContentMetadata({ custom: { playerType: PlayerType.Html5 }, assetName: 'MyAsset' });
       playerMock.eventEmitter.firePlayEvent();
 
       expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -74,7 +74,7 @@ describe('content metadata spec', () => {
     it('override streamType in custom tags', () => {
       jest.spyOn(playerMock, 'getPlayerType').mockReturnValue(PlayerType.Native);
       jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
-      convivaAnalytics.updateContentMetadata({ custom: { myTag: 'withMyValue', streamType: 'dash_vod' }, assetName: 'MyAsset' });
+      convivaAnalytics.updateContentMetadata({ custom: { streamType: 'dash_vod' }, assetName: 'MyAsset' });
       playerMock.eventEmitter.firePlayEvent();
 
       expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -83,7 +83,7 @@ describe('content metadata spec', () => {
     });
 
     it('override vrContentType in custom tags', () => {
-      convivaAnalytics.updateContentMetadata({ custom: { myTag: 'withMyValue', vrContentType: VRContentType.Single }, assetName: 'MyAsset' });
+      convivaAnalytics.updateContentMetadata({ custom: { vrContentType: VRContentType.Single }, assetName: 'MyAsset' });
       playerMock.eventEmitter.firePlayEvent();
 
       expect(convivaVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(expect.objectContaining({

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -463,10 +463,10 @@ export class ConvivaAnalytics {
     this.contentMetadataBuilder.assetName = this.getAssetNameFromSource(source);
     this.contentMetadataBuilder.viewerId = this.contentMetadataBuilder.viewerId;
     this.contentMetadataBuilder.custom = {
-      ...this.contentMetadataBuilder.custom,
       playerType: this.player.getPlayerType(),
       streamType: this.player.getStreamType(),
       vrContentType: source.vr && source.vr.contentType,
+      ...this.contentMetadataBuilder.custom,
     };
 
     this.contentMetadataBuilder.streamUrl = this.getUrlFromSource(source);


### PR DESCRIPTION
Currently `streamType`, `playerType` and `vrContentType` are 3 tags which are defined and populated internally by the Conviva integration. This PR is to allow application to override the values set in these internally.
- Customers may already be using these custom tag names but have a different set of values for these. So they would want to override the internal values.
- Allowing to override should not result in any issue as the values will be overridden if explicitly set externally. If customer want to use internal values, they should not override these. So allowing the override makes it possible to handle both scenarios.