### PR TITLE
Upgrade conviva sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bitmovin Player Conviva Analytics Integration
 ## Compatibility
 **This version of the Conviva Analytics Integration works only with Player Version >= 8.31.x.
-The recommended and tested version of the Conviva SDK is 4.0.15. See [CHANGELOG](CHANGELOG.md) for details.
+The recommended and tested version of the Conviva SDK is 4.5.7. See [CHANGELOG](CHANGELOG.md) for details.
 
 ## Getting Started
 ### Installation

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,7 +6,7 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
-    host: '0.0.0.0',
+    host: 'localhost',
     publicPath: '/dist/',
     contentBase: path.resolve(__dirname, 'example'),
     watchContentBase: true


### PR DESCRIPTION
There has been no major changes since the 4.0.15 release of the [conviva-js-codesdk](https://github.com/Conviva/conviva-js-coresdk). The 4.5.7 release has been verified working against Conviva Touchstone.