### PR TITLE
Add Github Action workflow to release a new version

### DIFF
--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -1,0 +1,37 @@
+const parseChangelog = require('changelog-parser');
+const semver = require('semver');
+
+async function defineReleaseVersion({ core }, currentVersion, changelogFile) {
+  return parseChangelog(changelogFile).then((result) => {
+    const unreleased = result.versions.find((entry) => entry.version === null);
+
+    if (!unreleased.parsed) {
+      core.error('No unreleased section found', unreleased);
+      return;
+    }
+
+    const parsedSections = unreleased.parsed;
+
+    const hasAddedSection = parsedSections.Added && parsedSections.Added.length > 0;
+    const hasChangedSection = parsedSections.Changed && parsedSections.Changed.length > 0;
+    const hasRemovedSection = parsedSections.Removed && parsedSections.Removed.length > 0;
+
+    const hasFixedSection = parsedSections.Fixed && parsedSections.Fixed.length > 0;
+    const hasSecurityEntries = parsedSections.Security && parsedSections.Security.length > 0;
+    const hasDeprecatedEntries = parsedSections.Deprecated && parsedSections.Deprecated.length > 0;
+
+    if (hasAddedSection || hasChangedSection || hasRemovedSection) {
+      const version = semver.inc(currentVersion, 'minor');
+      core.info(`Increase version from ${currentVersion} to ${version}`);
+      return version;
+    } else if (hasFixedSection || hasSecurityEntries || hasDeprecatedEntries) {
+      const version = semver.inc(currentVersion, 'patch');
+      core.info(`Increase version from ${currentVersion} to ${version}`);
+      return version;
+    } else {
+      core.error('No valid entries to release', unreleased);
+    }
+  });
+}
+
+module.exports.defineReleaseVersion = defineReleaseVersion;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          ref: develop
+
+      - name: Set up node.js
+        uses: actions/setup-node@v3.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+      - name: Read latest release version from package.json
+        uses: actions/github-script@v6
+        id: read-latest-release-version
+        with:
+          script: |
+            const { version } = require('./package.json')
+            core.info(`Latest release version is ${version}`)
+            core.setOutput('latestReleaseVersion', version)
+
+      - name: Define next release version based on Changelog entries
+        uses: actions/github-script@v6
+        id: define-release-version
+        with:
+          script: |
+            const { defineReleaseVersion } = require('./.github/scripts/defineVersion.js')
+            return defineReleaseVersion({core}, "${{ steps.read-latest-release-version.outputs.latestReleaseVersion }}", './CHANGELOG.md' )
+
+      - name: Bump package.json and Changelog version
+        run: |
+          npm --no-git-tag-version version "${{ fromJson(steps.define-release-version.outputs.result) }}"
+          npx kacl release
+
+      - name: Add tag and push changes
+        run: |
+          git config --global user.name 'Automated Release'
+          git config --global user.email 'release-automation@bitmovin.com'
+          git add .
+          git commit -m "Bump version and update changelog"
+          git tag -a "${{ fromJson(steps.define-release-version.outputs.result) }}" -m "v${{ fromJson(steps.define-release-version.outputs.result) }}"
+          git push origin develop
+          git push origin --tags
+
+      - name: build and publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+          npm publish
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ fromJson(steps.define-release-version.outputs.result) }}


### PR DESCRIPTION
Workflow to automatically increment the version (based on Changelog entries and current version in package.json), tag the commit, publish to npm and generate the Github release notes.

The Workflow is almost identical to our yospace integration: https://github.com/bitmovin/bitmovin-player-web-integrations-yospace/blob/develop/.github/workflows/release.yml
In the Yospace repo, the release workflow was already tested successfully, except for auto-generating the github release notes which was added after the last release.