### PR TITLE
Track initial audio track and subtitles after first play

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Track initial audio track and subtitles only after the first `Play` event
+
 ## [5.2.0] - 2024-07-08
 ### Added
 - Server side ad tracking

--- a/spec/tests/ConvivaAnalyticsTracker.spec.ts
+++ b/spec/tests/ConvivaAnalyticsTracker.spec.ts
@@ -36,4 +36,42 @@ describe(ConvivaAnalyticsTracker, () => {
     expect(MockHelper.latestAdAnalytics.reportAdMetric).not.toHaveBeenCalledWith(Conviva.Constants.Playback.RESOLUTION, expect.anything());
     expect(MockHelper.latestAdAnalytics.reportAdMetric).not.toHaveBeenCalledWith(Conviva.Constants.Playback.RENDERED_FRAMERATE, expect.anything());
   })
+
+  it('should report audio track on the first play', () => {
+    const {playerMock, playerEventHelper} = MockHelper.createPlayerMock();
+
+    new ConvivaAnalyticsTracker(playerMock, 'test-key');
+
+    playerEventHelper.firePlayEvent();
+
+    expect(MockHelper.latestVideoAnalytics.reportPlaybackMetric).toHaveBeenCalledWith(Conviva.Constants.Playback.AUDIO_LANGUAGE, expect.anything());
+  })
+
+  it('should report subtitles on the first play', () => {
+    const {playerMock, playerEventHelper} = MockHelper.createPlayerMock();
+
+    new ConvivaAnalyticsTracker(playerMock, 'test-key');
+
+    playerEventHelper.firePlayEvent();
+
+    expect(MockHelper.latestVideoAnalytics.reportPlaybackMetric).toHaveBeenCalledWith(Conviva.Constants.Playback.CLOSED_CAPTIONS_LANGUAGE, expect.anything());
+  })
+
+  it('should not report playback metrics after the first play', () => {
+    const {playerMock, playerEventHelper} = MockHelper.createPlayerMock();
+
+    new ConvivaAnalyticsTracker(playerMock, 'test-key');
+
+    playerEventHelper.firePlayEvent();
+    const invokedTimesBefore = getInvokedTimes(MockHelper.latestVideoAnalytics.reportPlaybackMetric);
+
+    playerEventHelper.firePlayEvent();
+    const invokedTimesAfter = getInvokedTimes(MockHelper.latestVideoAnalytics.reportPlaybackMetric);
+
+    expect(invokedTimesAfter).toBe(invokedTimesBefore);
+  })
 })
+
+const getInvokedTimes = (mock: unknown) => {
+  return (mock as jest.MockInstance<Function, any>).mock.calls.length;
+}

--- a/spec/tests/ConvivaAnalyticsTracker.spec.ts
+++ b/spec/tests/ConvivaAnalyticsTracker.spec.ts
@@ -73,5 +73,5 @@ describe(ConvivaAnalyticsTracker, () => {
 })
 
 const getInvokedTimes = (mock: unknown) => {
-  return (mock as jest.MockInstance<Function, any>).mock.calls.length;
+  return (mock as jest.MockInstance<Function, unknown[]>).mock.calls.length;
 }

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -134,6 +134,8 @@ export class ConvivaAnalyticsTracker {
     return this._isAdBreakActive;
   }
 
+  private hasPlayed = false;
+
   /**
    * Do not track play event during ad (e.g. triggered from IMA)
    */
@@ -452,12 +454,6 @@ export class ConvivaAnalyticsTracker {
         Conviva.SystemSettings.LogLevel.ERROR,
       );
     }
-
-    // Send the session init audio language values.
-    this.trackUpdateAudioTrack(this.player.getAudio());
-
-    // Check if at session init has a subtitle enabled.
-    this.trackSubtitleWhenInternalInitialize();
   }
 
   /**
@@ -530,6 +526,7 @@ export class ConvivaAnalyticsTracker {
     this.convivaAdAnalytics.release();
     this.convivaAdAnalytics = null;
 
+    this.hasPlayed = false;
     this._isAdBreakActive = false;
   };
 
@@ -606,6 +603,14 @@ export class ConvivaAnalyticsTracker {
     // In case the playback has finished and the user replays the stream create a new session
     if (!this.isSessionActive() && !this.sessionEndedExternally) {
       this.internalInitializeSession();
+    }
+
+    if (!this.hasPlayed) {
+      this.hasPlayed = true;
+      // Send the session init audio language values.
+      this.trackUpdateAudioTrack(this.player.getAudio());
+      // Check if at session init has a subtitle enabled.
+      this.trackInitialSubtitles();
     }
   };
 
@@ -811,7 +816,7 @@ export class ConvivaAnalyticsTracker {
     }
   }
 
-  private trackSubtitleWhenInternalInitialize() {
+  private trackInitialSubtitles() {
     if (!this.isSessionActive()) {
       return;
     }


### PR DESCRIPTION
Related to: https://bitmovin.atlassian.net/browse/PA-2533.

This change will allow users to initialize the session externally early, even before `player.load()`.
