### PR TITLE
Include ad events in stall tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Ad-related delays not contributing to rebuffering metrics
+
 ## [5.4.0] - 2024-08-27
 ### Added
 - Possibility to start session tracking without a `Player` instance

--- a/spec/tests/ConvivaAnalyticsTracker.spec.ts
+++ b/spec/tests/ConvivaAnalyticsTracker.spec.ts
@@ -1,3 +1,4 @@
+import { PlayerEvent, PlayerEventBase } from "bitmovin-player";
 import { ConvivaAnalyticsTracker } from "../../src/ts/ConvivaAnalyticsTracker";
 import { MockHelper } from "../helper/MockHelper";
 import * as Conviva from '@convivainc/conviva-js-coresdk';
@@ -74,6 +75,51 @@ describe(ConvivaAnalyticsTracker, () => {
     const invokedTimesAfter = getInvokedTimes(MockHelper.latestVideoAnalytics.reportPlaybackMetric);
 
     expect(invokedTimesAfter).toBe(invokedTimesBefore);
+  })
+
+  describe('trackPlaybackStateChanged', () => {
+    let convivaAnalyticsTracker: ConvivaAnalyticsTracker;
+
+    beforeEach(() => {
+      convivaAnalyticsTracker = new ConvivaAnalyticsTracker('test-key');
+
+      const {playerMock} = MockHelper.createPlayerMock();
+      convivaAnalyticsTracker.attachPlayer(playerMock);
+      jest.spyOn(playerMock, 'getSource').mockImplementation(() => ({ title: 'test-title' }));
+      convivaAnalyticsTracker.initializeSession();
+    })
+
+    test.each([
+      PlayerEvent.Play,
+      PlayerEvent.Seek,
+      PlayerEvent.TimeShift,
+      PlayerEvent.AdBreakStarted,
+      PlayerEvent.AdFinished,
+    ])('should start timer for stalling when reported player event is %s', (event) => {
+      const stallTrackingStartTimeoutSpy = jest.spyOn(convivaAnalyticsTracker['stallTrackingTimeout'], 'start');
+
+      convivaAnalyticsTracker.trackPlaybackStateChanged({ type: event } as PlayerEventBase);
+
+      expect(stallTrackingStartTimeoutSpy).toHaveBeenCalled();
+    })
+
+    test.each([
+      PlayerEvent.StallStarted,
+      PlayerEvent.Playing,
+      PlayerEvent.Paused,
+      PlayerEvent.Seeked,
+      PlayerEvent.TimeShifted,
+      PlayerEvent.StallEnded,
+      PlayerEvent.PlaybackFinished,
+      PlayerEvent.AdStarted,
+      PlayerEvent.AdBreakFinished,
+    ])('should clear timer for stalling when reported player event is %s', (event) => {
+      const stallTrackingStopTimeoutSpy = jest.spyOn(convivaAnalyticsTracker['stallTrackingTimeout'], 'clear');
+
+      convivaAnalyticsTracker.trackPlaybackStateChanged({ type: event } as PlayerEventBase);
+
+      expect(stallTrackingStopTimeoutSpy).toHaveBeenCalled();
+    })
   })
 })
 

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -273,6 +273,7 @@ export class ConvivaAnalytics {
     this.debugLog('[ ConvivaAnalytics ] [ Player Event ] adbreak started', event);
     this.lastAdBreakEvent = event;
     this.convivaAnalyticsTracker.trackAdBreakStarted(Conviva.Constants.AdType.CLIENT_SIDE);
+    this.convivaAnalyticsTracker.trackPlaybackStateChanged(event);
   };
 
   private onAdStarted = (event: AdEvent) => {
@@ -282,11 +283,13 @@ export class ConvivaAnalytics {
     const bitrateKbps = event.ad.data?.bitrate;
 
     this.convivaAnalyticsTracker.trackAdStarted(adInfo, Conviva.Constants.AdType.CLIENT_SIDE, bitrateKbps);
+    this.convivaAnalyticsTracker.trackPlaybackStateChanged(event);
   }
 
   private onAdFinished = (event: AdEvent) => {
     this.debugLog('[ ConvivaAnalytics ] [ Player Event ] ad finished', event);
     this.convivaAnalyticsTracker.trackAdFinished();
+    this.convivaAnalyticsTracker.trackPlaybackStateChanged(event);
   }
 
   private onAdSkipped = (event: AdEvent) => {
@@ -298,6 +301,7 @@ export class ConvivaAnalytics {
   private onAdBreakFinished = (event: AdBreakEvent) => {
     this.debugLog('[ ConvivaAnalytics ] [ Player Event ] adbreak finished', event);
     this.convivaAnalyticsTracker.trackAdBreakFinished();
+    this.convivaAnalyticsTracker.trackPlaybackStateChanged(event);
   };
 
   private onAdError = (event: ErrorEvent) => {

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -625,7 +625,7 @@ export class ConvivaAnalyticsTracker {
       PlayerEvent.AdFinished,
     ];
     const stallTrackingClearEvents = [
-      PlayerEvent.StallStarted,
+      PlayerEvent.StallStarted, // StallStarted is reported as BUFFERING immediately. Does not need the delayed timeout approach.
       PlayerEvent.Playing,
       PlayerEvent.Paused,
       PlayerEvent.Seeked,

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -621,6 +621,8 @@ export class ConvivaAnalyticsTracker {
       PlayerEvent.Play,
       PlayerEvent.Seek,
       PlayerEvent.TimeShift,
+      PlayerEvent.AdBreakStarted,
+      PlayerEvent.AdFinished,
     ];
     const stallTrackingClearEvents = [
       PlayerEvent.StallStarted,
@@ -630,6 +632,8 @@ export class ConvivaAnalyticsTracker {
       PlayerEvent.TimeShifted,
       PlayerEvent.StallEnded,
       PlayerEvent.PlaybackFinished,
+      PlayerEvent.AdStarted,
+      PlayerEvent.AdBreakFinished,
     ];
 
     if (stallTrackingStartEvents.indexOf(event.type) !== -1) {


### PR DESCRIPTION
Issue: https://bitmovin.atlassian.net/browse/PW-21228

Ad related delays are not contributing to the stalling metrics but should.