### PR TITLE
[PW-21587] Fix midroll reported as postroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed 
-- Mid rolls errorneously reported as post rolls when midroll's schedule time > the duration of the adbreak 
-- Adhelper testcases to use the source duration instead
-
-### Changed
-- Updated Bitmovin Player version to 8.191.0
-
+- Mid-roll ads erroneously reported as post-rolls when mid-roll's schedule time is greater than the duration of the ad
 
 ## [6.1.0] - 2024-12-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed 
 - Mid rolls errorneously reported as post rolls when midroll's schedule time > the duration of the adbreak 
+- Adhelper testcases to use the source duration instead
 
 ### Changed
 - Updated Bitmovin Player version to 8.191.0
+
 
 ### Fixed
 - Ad-related delays not contributing to rebuffering metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed 
+- Mid rolls errorneously reported as post rolls when midroll's schedule time > the duration of the adbreak 
+
+### Changed
+- Updated Bitmovin Player version to 8.191.0
 
 ### Fixed
 - Ad-related delays not contributing to rebuffering metrics

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^24.0.1",
-        "bitmovin-player": "^8.165.0",
+        "bitmovin-player": "^8.191.0",
         "bitmovin-player-ui": "^3.3.1",
         "changelog-parser": "^3.0.1",
         "create-file-webpack": "^1.0.2",
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/bitmovin-player": {
-      "version": "8.165.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.165.0.tgz",
-      "integrity": "sha512-UPQvQVZ1LZRrwOIUulyagf2BRg1q5UfmrRh57WqTlJkyaRyLEbfBHFH/ZRGD//u51GXy8VJXAHHCecAIDpGZyg==",
+      "version": "8.191.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.191.0.tgz",
+      "integrity": "sha512-QKBIf8glAUQm0fEVL2Iu6BlfFzfiIts6YDjgIzbNpmMYB4bEojvOR0Xt7u78g/PlCFMNGARztZuhH5ofJ79UkA==",
       "dev": true
     },
     "node_modules/bitmovin-player-ui": {
@@ -3512,30 +3512,34 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -3543,15 +3547,17 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3559,66 +3565,75 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -3628,24 +3643,27 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -3659,9 +3677,10 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3679,15 +3698,17 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3697,18 +3718,20 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3716,24 +3739,27 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -3743,15 +3769,17 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3761,15 +3789,17 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -3777,18 +3807,20 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
       },
@@ -3798,15 +3830,17 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -3821,9 +3855,10 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -3842,9 +3877,10 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -3855,24 +3891,27 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -3880,9 +3919,10 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -3892,54 +3932,60 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -3947,24 +3993,27 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -3977,15 +4026,17 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3998,9 +4049,10 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4010,57 +4062,65 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -4072,9 +4132,10 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -4084,18 +4145,20 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -4111,30 +4174,34 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -12324,9 +12391,9 @@
       }
     },
     "bitmovin-player": {
-      "version": "8.165.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.165.0.tgz",
-      "integrity": "sha512-UPQvQVZ1LZRrwOIUulyagf2BRg1q5UfmrRh57WqTlJkyaRyLEbfBHFH/ZRGD//u51GXy8VJXAHHCecAIDpGZyg==",
+      "version": "8.191.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.191.0.tgz",
+      "integrity": "sha512-QKBIf8glAUQm0fEVL2Iu6BlfFzfiIts6YDjgIzbNpmMYB4bEojvOR0Xt7u78g/PlCFMNGARztZuhH5ofJ79UkA==",
       "dev": true
     },
     "bitmovin-player-ui": {
@@ -14257,22 +14324,26 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -14281,12 +14352,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14295,32 +14368,38 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -14328,22 +14407,26 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -14351,12 +14434,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -14371,7 +14456,8 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -14384,12 +14470,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -14397,7 +14485,8 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -14405,7 +14494,8 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -14414,17 +14504,20 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14432,12 +14525,14 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14445,12 +14540,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -14459,7 +14556,8 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -14467,7 +14565,8 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -14475,12 +14574,14 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -14490,7 +14591,8 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -14507,7 +14609,8 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -14516,7 +14619,8 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -14524,12 +14628,14 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -14538,7 +14644,8 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -14549,17 +14656,20 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14567,17 +14677,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -14586,17 +14699,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -14607,14 +14723,16 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -14628,7 +14746,8 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -14636,37 +14755,44 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -14674,7 +14800,8 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14684,7 +14811,8 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14692,12 +14820,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -14711,12 +14841,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -14724,12 +14856,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.1",
-    "bitmovin-player": "^8.165.0",
+    "bitmovin-player": "^8.191.0",
     "bitmovin-player-ui": "^3.3.1",
     "changelog-parser": "^3.0.1",
     "create-file-webpack": "^1.0.2",

--- a/spec/tests/AdHelper.spec.ts
+++ b/spec/tests/AdHelper.spec.ts
@@ -5,30 +5,30 @@ import * as Conviva from '@convivainc/conviva-js-coresdk';
 describe(AdHelper, () => {
   describe('mapAdPosition', () => {
     it('should map ad position to preroll', () => {
-      const duration = 100;
+      const mainContentDuration = 100;
       const adBreak = {
         scheduleTime: 0
       } as AdBreak;
 
-      expect(AdHelper.mapCsaiAdPosition(adBreak, duration)).toEqual(Conviva.Constants.AdPosition.PREROLL)
+      expect(AdHelper.mapCsaiAdPosition(adBreak, mainContentDuration)).toEqual(Conviva.Constants.AdPosition.PREROLL)
     })
 
     it('should map ad position to postroll', () => {
-      const duration = 100;
+      const mainContentDuration = 100;
       const adBreak = {
         scheduleTime: 100
       } as AdBreak;
 
-      expect(AdHelper.mapCsaiAdPosition(adBreak, duration)).toEqual(Conviva.Constants.AdPosition.POSTROLL)
+      expect(AdHelper.mapCsaiAdPosition(adBreak, mainContentDuration)).toEqual(Conviva.Constants.AdPosition.POSTROLL)
     })
 
     it('should map ad position to midroll', () => {
-      const duration = 100;
+      const mainContentDuration = 100;
       const adBreak = {
         scheduleTime: 50
       } as AdBreak;
 
-      expect(AdHelper.mapCsaiAdPosition(adBreak, duration)).toEqual(Conviva.Constants.AdPosition.MIDROLL)
+      expect(AdHelper.mapCsaiAdPosition(adBreak, mainContentDuration)).toEqual(Conviva.Constants.AdPosition.MIDROLL)
     })
   })
 
@@ -60,8 +60,7 @@ describe(AdHelper, () => {
 
   describe('extractConvivaAdInfo', () => {
     it('should extract minimal Conviva ad info', () => {
-      const player = {} as PlayerAPI;
-      const duration = 100;
+      const mainContentDuration = 100;
       const adBreakEvent = {
         adBreak: {
           scheduleTime: 0
@@ -74,7 +73,7 @@ describe(AdHelper, () => {
         },
       } as AdEvent;
 
-      expect(AdHelper.extractCsaiConvivaAdInfo(player, adBreakEvent, duration, adEvent)).toEqual({
+      expect(AdHelper.extractCsaiConvivaAdInfo(adBreakEvent, mainContentDuration, adEvent)).toEqual({
         "c3.ad.creativeId": "NA",
         "c3.ad.firstAdId": "123",
         "c3.ad.firstAdSystem": "NA",
@@ -90,8 +89,7 @@ describe(AdHelper, () => {
     })
 
     it('should extract full Conviva ad info', () => {
-      const player = {} as PlayerAPI;
-      const duration = 100;
+      const mainContentDuration = 100;
       const adBreakEvent = {
         adBreak: {
           scheduleTime: 0
@@ -115,7 +113,7 @@ describe(AdHelper, () => {
         } as Ad | LinearAd,
       } as AdEvent;
 
-      expect(AdHelper.extractCsaiConvivaAdInfo(player, adBreakEvent, duration, adEvent)).toEqual({
+      expect(AdHelper.extractCsaiConvivaAdInfo(adBreakEvent, mainContentDuration, adEvent)).toEqual({
         [Conviva.Constants.ASSET_NAME]: "Test title",
         [Conviva.Constants.STREAM_URL]: 'https://test.com',
         [Conviva.Constants.DURATION]: 100,

--- a/spec/tests/AdHelper.spec.ts
+++ b/spec/tests/AdHelper.spec.ts
@@ -5,7 +5,7 @@ import * as Conviva from '@convivainc/conviva-js-coresdk';
 describe(AdHelper, () => {
   describe('mapAdPosition', () => {
     it('should map ad position to preroll', () => {
-      const duration = 100 as number;
+      const duration = 100;
       const adBreak = {
         scheduleTime: 0
       } as AdBreak;
@@ -14,7 +14,7 @@ describe(AdHelper, () => {
     })
 
     it('should map ad position to postroll', () => {
-      const duration = 100 as number;
+      const duration = 100;
       const adBreak = {
         scheduleTime: 100
       } as AdBreak;
@@ -23,7 +23,7 @@ describe(AdHelper, () => {
     })
 
     it('should map ad position to midroll', () => {
-      const duration = 100 as number;
+      const duration = 100;
       const adBreak = {
         scheduleTime: 50
       } as AdBreak;
@@ -61,7 +61,7 @@ describe(AdHelper, () => {
   describe('extractConvivaAdInfo', () => {
     it('should extract minimal Conviva ad info', () => {
       const player = {} as PlayerAPI;
-      const duration = 100 as number;
+      const duration = 100;
       const adBreakEvent = {
         adBreak: {
           scheduleTime: 0
@@ -91,7 +91,7 @@ describe(AdHelper, () => {
 
     it('should extract full Conviva ad info', () => {
       const player = {} as PlayerAPI;
-      const duration = 100 as number;
+      const duration = 100;
       const adBreakEvent = {
         adBreak: {
           scheduleTime: 0

--- a/spec/tests/AdHelper.spec.ts
+++ b/spec/tests/AdHelper.spec.ts
@@ -5,36 +5,30 @@ import * as Conviva from '@convivainc/conviva-js-coresdk';
 describe(AdHelper, () => {
   describe('mapAdPosition', () => {
     it('should map ad position to preroll', () => {
-      const player = {
-        getDuration: () => 100,
-      } as PlayerAPI;
+      const duration = 100 as number;
       const adBreak = {
         scheduleTime: 0
       } as AdBreak;
 
-      expect(AdHelper.mapCsaiAdPosition(adBreak, player)).toEqual(Conviva.Constants.AdPosition.PREROLL)
+      expect(AdHelper.mapCsaiAdPosition(adBreak, duration)).toEqual(Conviva.Constants.AdPosition.PREROLL)
     })
 
     it('should map ad position to postroll', () => {
-      const player = {
-        getDuration: () => 100,
-      } as PlayerAPI;
+      const duration = 100 as number;
       const adBreak = {
         scheduleTime: 100
       } as AdBreak;
 
-      expect(AdHelper.mapCsaiAdPosition(adBreak, player)).toEqual(Conviva.Constants.AdPosition.POSTROLL)
+      expect(AdHelper.mapCsaiAdPosition(adBreak, duration)).toEqual(Conviva.Constants.AdPosition.POSTROLL)
     })
 
     it('should map ad position to midroll', () => {
-      const player = {
-        getDuration: () => 100,
-      } as PlayerAPI;
+      const duration = 100 as number;
       const adBreak = {
         scheduleTime: 50
       } as AdBreak;
 
-      expect(AdHelper.mapCsaiAdPosition(adBreak, player)).toEqual(Conviva.Constants.AdPosition.MIDROLL)
+      expect(AdHelper.mapCsaiAdPosition(adBreak, duration)).toEqual(Conviva.Constants.AdPosition.MIDROLL)
     })
   })
 
@@ -67,6 +61,7 @@ describe(AdHelper, () => {
   describe('extractConvivaAdInfo', () => {
     it('should extract minimal Conviva ad info', () => {
       const player = {} as PlayerAPI;
+      const duration = 100 as number;
       const adBreakEvent = {
         adBreak: {
           scheduleTime: 0
@@ -79,7 +74,7 @@ describe(AdHelper, () => {
         },
       } as AdEvent;
 
-      expect(AdHelper.extractCsaiConvivaAdInfo(player, adBreakEvent, adEvent)).toEqual({
+      expect(AdHelper.extractCsaiConvivaAdInfo(player, adBreakEvent, duration, adEvent)).toEqual({
         "c3.ad.creativeId": "NA",
         "c3.ad.firstAdId": "123",
         "c3.ad.firstAdSystem": "NA",
@@ -96,6 +91,7 @@ describe(AdHelper, () => {
 
     it('should extract full Conviva ad info', () => {
       const player = {} as PlayerAPI;
+      const duration = 100 as number;
       const adBreakEvent = {
         adBreak: {
           scheduleTime: 0
@@ -119,7 +115,7 @@ describe(AdHelper, () => {
         } as Ad | LinearAd,
       } as AdEvent;
 
-      expect(AdHelper.extractCsaiConvivaAdInfo(player, adBreakEvent, adEvent)).toEqual({
+      expect(AdHelper.extractCsaiConvivaAdInfo(player, adBreakEvent, duration, adEvent)).toEqual({
         [Conviva.Constants.ASSET_NAME]: "Test title",
         [Conviva.Constants.STREAM_URL]: 'https://test.com',
         [Conviva.Constants.DURATION]: 100,

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -45,7 +45,10 @@ export class ConvivaAnalytics {
 
   private readonly logger: Conviva.LoggingInterface = new Html5Logging();
 
-  private duration: number = 0;
+  /**
+   * Tracks the duration of main content. Needed as the player may return the ad duration instead.
+   */
+  private mainContentDuration = 0;
 
   public readonly ssai: Omit<ConvivaAnalyticsSsai, 'reset'>;
 
@@ -281,7 +284,7 @@ export class ConvivaAnalytics {
   private onAdStarted = (event: AdEvent) => {
     this.debugLog('[ ConvivaAnalytics ] [ Player Event ] ad started', event);
 
-    const adInfo = AdHelper.extractCsaiConvivaAdInfo(this.player, this.lastAdBreakEvent, this.duration, event);
+    const adInfo = AdHelper.extractCsaiConvivaAdInfo(this.lastAdBreakEvent, this.mainContentDuration, event);
     const bitrateKbps = event.ad.data?.bitrate;
 
     this.convivaAnalyticsTracker.trackAdStarted(adInfo, Conviva.Constants.AdType.CLIENT_SIDE, bitrateKbps);
@@ -368,7 +371,7 @@ export class ConvivaAnalytics {
 
   private onSourceLoaded = (event: PlayerEventBase) => {
     this.debugLog('[ ConvivaAnalytics ] [ Player Event ] onSourceLoaded', event);
-    this.duration = this.player.getDuration();
+    this.mainContentDuration = this.player.getDuration();
   };
 
   private registerPlayerEvents(): void {

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -45,6 +45,8 @@ export class ConvivaAnalytics {
 
   private readonly logger: Conviva.LoggingInterface = new Html5Logging();
 
+  private duration: number = 0;
+
   public readonly ssai: Omit<ConvivaAnalyticsSsai, 'reset'>;
 
   constructor(player: PlayerAPI | undefined, customerKey: string, config: ConvivaAnalyticsConfiguration = {}) {
@@ -279,7 +281,7 @@ export class ConvivaAnalytics {
   private onAdStarted = (event: AdEvent) => {
     this.debugLog('[ ConvivaAnalytics ] [ Player Event ] ad started', event);
 
-    const adInfo = AdHelper.extractCsaiConvivaAdInfo(this.player, this.lastAdBreakEvent, event);
+    const adInfo = AdHelper.extractCsaiConvivaAdInfo(this.player, this.lastAdBreakEvent, this.duration, event);
     const bitrateKbps = event.ad.data?.bitrate;
 
     this.convivaAnalyticsTracker.trackAdStarted(adInfo, Conviva.Constants.AdType.CLIENT_SIDE, bitrateKbps);
@@ -360,7 +362,13 @@ export class ConvivaAnalytics {
     this.releaseInternal(event);
   };
 
+  private onSourceLoaded = (event: PlayerEventBase) => {
+    this.debugLog('[ ConvivaAnalytics ] [ Player Event ] onSourceLoaded', event);
+    this.duration = this.player.getDuration();
+  };
+
   private registerPlayerEvents(): void {
+    this.handlers.add(PlayerEvent.SourceLoaded, this.onSourceLoaded);
     this.handlers.add(PlayerEvent.Play, this.onPlay);
     this.handlers.add(PlayerEvent.Playing, this.onPlaying);
     this.handlers.add(PlayerEvent.Paused, this.onPlaybackStateChanged);

--- a/src/ts/helper/AdHelper.ts
+++ b/src/ts/helper/AdHelper.ts
@@ -43,13 +43,14 @@ export interface SsaiAdInfo {
 export class AdHelper {
   public static mapCsaiAdPosition(
     adBreak: AdBreak,
-    player: PlayerAPI,
+    duration: number,
   ): Conviva.valueof<Conviva.ConvivaConstants['AdPosition']> {
+
     if (adBreak.scheduleTime <= 0) {
       return Conviva.Constants.AdPosition.PREROLL;
     }
 
-    if (adBreak.scheduleTime >= player.getDuration()) {
+    if (adBreak.scheduleTime >= duration) {
       return Conviva.Constants.AdPosition.POSTROLL;
     }
 
@@ -76,7 +77,7 @@ export class AdHelper {
     return formattedErrorParts.join(' ');
   }
 
-  public static extractCsaiConvivaAdInfo(player: PlayerAPI, adBreakEvent: AdBreakEvent, adEvent: AdEvent): Conviva.ConvivaMetadata {
+  public static extractCsaiConvivaAdInfo(player: PlayerAPI, adBreakEvent: AdBreakEvent, duration: number, adEvent: AdEvent): Conviva.ConvivaMetadata {
     const ad = adEvent.ad as Ad | LinearAd;
     const adData = ad.data as undefined | AdData | VastAdData;
 
@@ -107,7 +108,7 @@ export class AdHelper {
     const adInfo: Conviva.ConvivaMetadata = {
       'c3.ad.id': ad.id,
       'c3.ad.technology': Conviva.Constants.AdType.CLIENT_SIDE,
-      'c3.ad.position': AdHelper.mapCsaiAdPosition(adBreakEvent.adBreak, player),
+      'c3.ad.position': AdHelper.mapCsaiAdPosition(adBreakEvent.adBreak, duration),
       'c3.ad.system': adSystemName,
       'c3.ad.creativeId': creativeId,
       'c3.ad.firstAdId': firstAdId,

--- a/src/ts/helper/AdHelper.ts
+++ b/src/ts/helper/AdHelper.ts
@@ -43,14 +43,14 @@ export interface SsaiAdInfo {
 export class AdHelper {
   public static mapCsaiAdPosition(
     adBreak: AdBreak,
-    duration: number,
+    mainContentDuration: number,
   ): Conviva.valueof<Conviva.ConvivaConstants['AdPosition']> {
 
     if (adBreak.scheduleTime <= 0) {
       return Conviva.Constants.AdPosition.PREROLL;
     }
 
-    if (adBreak.scheduleTime >= duration) {
+    if (adBreak.scheduleTime >= mainContentDuration) {
       return Conviva.Constants.AdPosition.POSTROLL;
     }
 
@@ -77,7 +77,11 @@ export class AdHelper {
     return formattedErrorParts.join(' ');
   }
 
-  public static extractCsaiConvivaAdInfo(player: PlayerAPI, adBreakEvent: AdBreakEvent, duration: number, adEvent: AdEvent): Conviva.ConvivaMetadata {
+  public static extractCsaiConvivaAdInfo(
+    adBreakEvent: AdBreakEvent,
+    mainContentDuration: number,
+    adEvent: AdEvent,
+  ): Conviva.ConvivaMetadata {
     const ad = adEvent.ad as Ad | LinearAd;
     const adData = ad.data as undefined | AdData | VastAdData;
 
@@ -108,7 +112,7 @@ export class AdHelper {
     const adInfo: Conviva.ConvivaMetadata = {
       'c3.ad.id': ad.id,
       'c3.ad.technology': Conviva.Constants.AdType.CLIENT_SIDE,
-      'c3.ad.position': AdHelper.mapCsaiAdPosition(adBreakEvent.adBreak, duration),
+      'c3.ad.position': AdHelper.mapCsaiAdPosition(adBreakEvent.adBreak, mainContentDuration),
       'c3.ad.system': adSystemName,
       'c3.ad.creativeId': creativeId,
       'c3.ad.firstAdId': firstAdId,


### PR DESCRIPTION
player.getDuration returns the ad duration hence if midroll schedule time > the duration of the adbreak it's errorneously reported as post-roll.

change: onsourceloaded event store the main content's duration and use that to do the above comparison, if the comparison might happen during an ad break