### PR TITLE
[PW-21834] Improve VST tracking

### DIFF
--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -33,7 +33,7 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
       core.info(`Increase version from ${currentVersion} to ${version}`);
       return version;
     } else {
-      core.error('No valid entries to release', unreleased);
+      core.error('No valid entries to release', unreleased, parsedSections);
     }
   });
 }

--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -33,7 +33,7 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
       core.info(`Increase version from ${currentVersion} to ${version}`);
       return version;
     } else {
-      core.error('No valid entries to release');
+      core.error('No valid entries to release', unreleased);
     }
   });
 }

--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -1,7 +1,7 @@
 const parseChangelog = require('changelog-parser');
 const semver = require('semver');
 
-async function defineReleaseVersion({ core }, currentVersion, changelogFile) {
+async function defineReleaseVersion({ core }, currentVersion, changelogFile, isMajorRelease) {
   return parseChangelog(changelogFile).then((result) => {
     const unreleased = result.versions.find((entry) => entry.version === null);
 
@@ -20,7 +20,11 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile) {
     const hasSecurityEntries = parsedSections.Security && parsedSections.Security.length > 0;
     const hasDeprecatedEntries = parsedSections.Deprecated && parsedSections.Deprecated.length > 0;
 
-    if (hasAddedSection || hasChangedSection || hasRemovedSection) {
+    if (isMajorRelease) {
+      const version = semver.inc(currentVersion, 'major');
+      core.info(`Increase version from ${currentVersion} to ${version}`);
+      return version;
+    } else if (hasAddedSection || hasChangedSection || hasRemovedSection) {
       const version = semver.inc(currentVersion, 'minor');
       core.info(`Increase version from ${currentVersion} to ${version}`);
       return version;

--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -33,7 +33,7 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
       core.info(`Increase version from ${currentVersion} to ${version}`);
       return version;
     } else {
-      core.error('No valid entries to release\n' + JSON.stringify(unreleased, null, '  ') + '\n' + JSON.stringify(parsedSections, null, '  '));
+      core.error('No valid entries to release, ' + JSON.stringify(unreleased) + ', ' + JSON.stringify(parsedSections));
     }
   });
 }

--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -10,8 +10,6 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
       return;
     }
 
-    console.log('defining release version...');
-
     const parsedSections = unreleased.parsed;
 
     const hasAddedSection = parsedSections.Added && parsedSections.Added.length > 0;
@@ -21,21 +19,6 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
     const hasFixedSection = parsedSections.Fixed && parsedSections.Fixed.length > 0;
     const hasSecurityEntries = parsedSections.Security && parsedSections.Security.length > 0;
     const hasDeprecatedEntries = parsedSections.Deprecated && parsedSections.Deprecated.length > 0;
-
-    const dataObj = {
-      unreleased,
-      parsedSections,
-      hasAddedSection,
-      hasChangedSection,
-      hasRemovedSection,
-      hasFixedSection,
-      hasSecurityEntries,
-      hasDeprecatedEntries,
-    };
-    const dataStr = JSON.stringify(dataObj, null, '  ');
-
-    console.log(dataStr);
-    core.info(dataStr);
 
     if (isMajorRelease) {
       const version = semver.inc(currentVersion, 'major');
@@ -50,7 +33,7 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
       core.info(`Increase version from ${currentVersion} to ${version}`);
       return version;
     } else {
-      core.error('No valid entries to release, ' + JSON.stringify(unreleased) + ', ' + JSON.stringify(parsedSections));
+      core.error('No valid entries to release');
     }
   });
 }

--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -33,7 +33,7 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
       core.info(`Increase version from ${currentVersion} to ${version}`);
       return version;
     } else {
-      core.error('No valid entries to release', unreleased, parsedSections);
+      core.error('No valid entries to release\n' + JSON.stringify(unreleased, null, '  ') + '\n' + JSON.stringify(parsedSections, null, '  '));
     }
   });
 }

--- a/.github/scripts/defineVersion.js
+++ b/.github/scripts/defineVersion.js
@@ -10,6 +10,8 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
       return;
     }
 
+    console.log('defining release version...');
+
     const parsedSections = unreleased.parsed;
 
     const hasAddedSection = parsedSections.Added && parsedSections.Added.length > 0;
@@ -19,6 +21,21 @@ async function defineReleaseVersion({ core }, currentVersion, changelogFile, isM
     const hasFixedSection = parsedSections.Fixed && parsedSections.Fixed.length > 0;
     const hasSecurityEntries = parsedSections.Security && parsedSections.Security.length > 0;
     const hasDeprecatedEntries = parsedSections.Deprecated && parsedSections.Deprecated.length > 0;
+
+    const dataObj = {
+      unreleased,
+      parsedSections,
+      hasAddedSection,
+      hasChangedSection,
+      hasRemovedSection,
+      hasFixedSection,
+      hasSecurityEntries,
+      hasDeprecatedEntries,
+    };
+    const dataStr = JSON.stringify(dataObj, null, '  ');
+
+    console.log(dataStr);
+    core.info(dataStr);
 
     if (isMajorRelease) {
       const version = semver.inc(currentVersion, 'major');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
-          ref: develop
+          ref: feature/PW-21834/improve-vst-tracking
 
       - name: Set up node.js
         uses: actions/setup-node@v3.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
-          ref: feature/PW-21834/improve-vst-tracking
+          ref: develop
 
       - name: Set up node.js
         uses: actions/setup-node@v3.3.0
@@ -55,28 +55,28 @@ jobs:
             const { defineReleaseVersion } = require('./.github/scripts/defineVersion.js')
             return defineReleaseVersion({core}, "${{ steps.read-latest-release-version.outputs.latestReleaseVersion }}", './CHANGELOG.md', ${{ inputs.is-major-release }})
 
-#      - name: Bump package.json and Changelog version
-#        run: |
-#          npm --no-git-tag-version version "${{ fromJson(steps.define-release-version.outputs.result) }}"
-#          npx kacl release
-#
-#      - name: Add tag and push changes
-#        run: |
-#          git config --global user.name 'Automated Release'
-#          git config --global user.email 'release-automation@bitmovin.com'
-#          git add .
-#          git commit -m "Bump version and update changelog"
-#          git tag -a "${{ fromJson(steps.define-release-version.outputs.result) }}" -m "v${{ fromJson(steps.define-release-version.outputs.result) }}"
-#          git push origin develop
-#          git push origin --tags
-#
-#      - name: build and publish
-#        run: |
-#          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
-#          npm publish
-#
-#      - name: Create GitHub release
-#        uses: softprops/action-gh-release@v2
-#        with:
-#          generate_release_notes: true
-#          tag_name: ${{ fromJson(steps.define-release-version.outputs.result) }}
+      - name: Bump package.json and Changelog version
+        run: |
+          npm --no-git-tag-version version "${{ fromJson(steps.define-release-version.outputs.result) }}"
+          npx kacl release
+
+      - name: Add tag and push changes
+        run: |
+          git config --global user.name 'Automated Release'
+          git config --global user.email 'release-automation@bitmovin.com'
+          git add .
+          git commit -m "Bump version and update changelog"
+          git tag -a "${{ fromJson(steps.define-release-version.outputs.result) }}" -m "v${{ fromJson(steps.define-release-version.outputs.result) }}"
+          git push origin develop
+          git push origin --tags
+
+      - name: build and publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+          npm publish
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ fromJson(steps.define-release-version.outputs.result) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,12 @@ name: Release new version
 
 on:
   workflow_dispatch:
+    inputs:
+      is-major-release:
+        type: boolean
+        description: Is this a major release?
+        required: false
+        default: false
 
 jobs:
   release:
@@ -47,30 +53,30 @@ jobs:
         with:
           script: |
             const { defineReleaseVersion } = require('./.github/scripts/defineVersion.js')
-            return defineReleaseVersion({core}, "${{ steps.read-latest-release-version.outputs.latestReleaseVersion }}", './CHANGELOG.md' )
+            return defineReleaseVersion({core}, "${{ steps.read-latest-release-version.outputs.latestReleaseVersion }}", './CHANGELOG.md', ${{ inputs.is-major-release }})
 
-      - name: Bump package.json and Changelog version
-        run: |
-          npm --no-git-tag-version version "${{ fromJson(steps.define-release-version.outputs.result) }}"
-          npx kacl release
-
-      - name: Add tag and push changes
-        run: |
-          git config --global user.name 'Automated Release'
-          git config --global user.email 'release-automation@bitmovin.com'
-          git add .
-          git commit -m "Bump version and update changelog"
-          git tag -a "${{ fromJson(steps.define-release-version.outputs.result) }}" -m "v${{ fromJson(steps.define-release-version.outputs.result) }}"
-          git push origin develop
-          git push origin --tags
-
-      - name: build and publish
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
-          npm publish
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          tag_name: ${{ fromJson(steps.define-release-version.outputs.result) }}
+#      - name: Bump package.json and Changelog version
+#        run: |
+#          npm --no-git-tag-version version "${{ fromJson(steps.define-release-version.outputs.result) }}"
+#          npx kacl release
+#
+#      - name: Add tag and push changes
+#        run: |
+#          git config --global user.name 'Automated Release'
+#          git config --global user.email 'release-automation@bitmovin.com'
+#          git add .
+#          git commit -m "Bump version and update changelog"
+#          git tag -a "${{ fromJson(steps.define-release-version.outputs.result) }}" -m "v${{ fromJson(steps.define-release-version.outputs.result) }}"
+#          git push origin develop
+#          git push origin --tags
+#
+#      - name: build and publish
+#        run: |
+#          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+#          npm publish
+#
+#      - name: Create GitHub release
+#        uses: softprops/action-gh-release@v2
+#        with:
+#          generate_release_notes: true
+#          tag_name: ${{ fromJson(steps.define-release-version.outputs.result) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Overreported VST after playing CSAI pre-rolls
 
 ## [5.4.1] - 2024-11-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Update `bitmovin-player` dependency to `~8.158.1` 
+  - Necessary due to dependency on newly introduced `PlayerEvent.RestoringContent` event
+
 ### Fixed
 - Overreported VST after playing CSAI pre-rolls
 

--- a/example/index.html
+++ b/example/index.html
@@ -33,7 +33,7 @@
         box-shadow: 0 0 30px rgba(0, 0, 0, 0.7);
       }
     </style>
-    <script src="//cdn.bitmovin.com/player/web/8.31.0/bitmovinplayer.js"></script>
+    <script src="//cdn.bitmovin.com/player/web/8.192.1-beta.0/bitmovinplayer.js"></script>
     <script src="./conviva-core-sdk.js"></script>
     <script src="./dist/bitmovin-player-analytics-conviva.js"></script>
   </head>

--- a/example/index.html
+++ b/example/index.html
@@ -33,7 +33,7 @@
         box-shadow: 0 0 30px rgba(0, 0, 0, 0.7);
       }
     </style>
-    <script src="//cdn.bitmovin.com/player/web/8.192.1-beta.0/bitmovinplayer.js"></script>
+    <script src="//cdn.bitmovin.com/player/web/8.158.1/bitmovinplayer.js"></script>
     <script src="./conviva-core-sdk.js"></script>
     <script src="./dist/bitmovin-player-analytics-conviva.js"></script>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^24.0.1",
-        "bitmovin-player": "^8.165.0",
-        "bitmovin-player-ui": "^3.3.1",
+        "bitmovin-player": "^8.192.1-beta.0",
+        "bitmovin-player-ui": "^3.75.0",
         "changelog-parser": "^3.0.1",
         "create-file-webpack": "^1.0.2",
         "husky": "^8.0.3",
@@ -1106,15 +1106,15 @@
       }
     },
     "node_modules/bitmovin-player": {
-      "version": "8.165.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.165.0.tgz",
-      "integrity": "sha512-UPQvQVZ1LZRrwOIUulyagf2BRg1q5UfmrRh57WqTlJkyaRyLEbfBHFH/ZRGD//u51GXy8VJXAHHCecAIDpGZyg==",
+      "version": "8.192.1-beta.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.192.1-beta.0.tgz",
+      "integrity": "sha512-Zst2zNzXd3ZFJ0JOifd9sO2+uvsc1+APO/LfDhJxNk9i4+qkic178LH+CGirlAwRaK7cZTLsWNyKgtqBFqZtVQ==",
       "dev": true
     },
     "node_modules/bitmovin-player-ui": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.3.1.tgz",
-      "integrity": "sha512-gY/gkUnqltGtdry9srQNWFRH2dMxg5mfeHVgHtoTF66nDEKwQ85Z9QV6KPigCtu50ruI+QboiNUqD3U12HD0+A==",
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.75.0.tgz",
+      "integrity": "sha512-5afSK7lkEN/7QBEyw1E37dT78aGJs8vA8ys7/c6Rnqo+rcKPcGL/UU959jDr7IQZ4kG+k4JJynVDDrtGEKJ+gA==",
       "dev": true
     },
     "node_modules/bluebird": {
@@ -3512,30 +3512,34 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -3543,15 +3547,17 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3559,66 +3565,75 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -3628,24 +3643,27 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -3659,9 +3677,10 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3679,15 +3698,17 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3697,18 +3718,20 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3716,24 +3739,27 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -3743,15 +3769,17 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3761,15 +3789,17 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -3777,18 +3807,20 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
       },
@@ -3798,15 +3830,17 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -3821,9 +3855,10 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -3842,9 +3877,10 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -3855,24 +3891,27 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -3880,9 +3919,10 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -3892,54 +3932,60 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -3947,24 +3993,27 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -3977,15 +4026,17 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3998,9 +4049,10 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4010,57 +4062,65 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -4072,9 +4132,10 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -4084,18 +4145,20 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -4111,30 +4174,34 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -12324,15 +12391,15 @@
       }
     },
     "bitmovin-player": {
-      "version": "8.165.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.165.0.tgz",
-      "integrity": "sha512-UPQvQVZ1LZRrwOIUulyagf2BRg1q5UfmrRh57WqTlJkyaRyLEbfBHFH/ZRGD//u51GXy8VJXAHHCecAIDpGZyg==",
+      "version": "8.192.1-beta.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.192.1-beta.0.tgz",
+      "integrity": "sha512-Zst2zNzXd3ZFJ0JOifd9sO2+uvsc1+APO/LfDhJxNk9i4+qkic178LH+CGirlAwRaK7cZTLsWNyKgtqBFqZtVQ==",
       "dev": true
     },
     "bitmovin-player-ui": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.3.1.tgz",
-      "integrity": "sha512-gY/gkUnqltGtdry9srQNWFRH2dMxg5mfeHVgHtoTF66nDEKwQ85Z9QV6KPigCtu50ruI+QboiNUqD3U12HD0+A==",
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.75.0.tgz",
+      "integrity": "sha512-5afSK7lkEN/7QBEyw1E37dT78aGJs8vA8ys7/c6Rnqo+rcKPcGL/UU959jDr7IQZ4kG+k4JJynVDDrtGEKJ+gA==",
       "dev": true
     },
     "bluebird": {
@@ -14257,22 +14324,26 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -14281,12 +14352,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14295,32 +14368,38 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -14328,22 +14407,26 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -14351,12 +14434,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -14371,7 +14456,8 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -14384,12 +14470,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -14397,7 +14485,8 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -14405,7 +14494,8 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -14414,17 +14504,20 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14432,12 +14525,14 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14445,12 +14540,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -14459,7 +14556,8 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -14467,7 +14565,8 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -14475,12 +14574,14 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -14490,7 +14591,8 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -14507,7 +14609,8 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -14516,7 +14619,8 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -14524,12 +14628,14 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -14538,7 +14644,8 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -14549,17 +14656,20 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14567,17 +14677,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -14586,17 +14699,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -14607,14 +14723,16 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -14628,7 +14746,8 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -14636,37 +14755,44 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -14674,7 +14800,8 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14684,7 +14811,8 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14692,12 +14820,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -14711,12 +14841,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -14724,12 +14856,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^24.0.1",
-        "bitmovin-player": "^8.192.1-beta.0",
-        "bitmovin-player-ui": "^3.75.0",
+        "bitmovin-player": "~8.158.1",
+        "bitmovin-player-ui": "^3.55.0",
         "changelog-parser": "^3.0.1",
         "create-file-webpack": "^1.0.2",
         "husky": "^8.0.3",
@@ -33,7 +33,7 @@
       },
       "peerDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.6",
-        "bitmovin-player": "^8.165.0"
+        "bitmovin-player": "~8.158.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/bitmovin-player": {
-      "version": "8.192.1-beta.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.192.1-beta.0.tgz",
-      "integrity": "sha512-Zst2zNzXd3ZFJ0JOifd9sO2+uvsc1+APO/LfDhJxNk9i4+qkic178LH+CGirlAwRaK7cZTLsWNyKgtqBFqZtVQ==",
+      "version": "8.158.1",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.158.1.tgz",
+      "integrity": "sha512-kbDMNCzyHOJuYOZPiSlJVR5tvsYLQpKFBoLRSnI00ineDU9rrZR0PbOTcHsY5OoRIT/XHxrgRmpVO6/eh+4oYQ==",
       "dev": true
     },
     "node_modules/bitmovin-player-ui": {
@@ -12391,9 +12391,9 @@
       }
     },
     "bitmovin-player": {
-      "version": "8.192.1-beta.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.192.1-beta.0.tgz",
-      "integrity": "sha512-Zst2zNzXd3ZFJ0JOifd9sO2+uvsc1+APO/LfDhJxNk9i4+qkic178LH+CGirlAwRaK7cZTLsWNyKgtqBFqZtVQ==",
+      "version": "8.158.1",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.158.1.tgz",
+      "integrity": "sha512-kbDMNCzyHOJuYOZPiSlJVR5tvsYLQpKFBoLRSnI00ineDU9rrZR0PbOTcHsY5OoRIT/XHxrgRmpVO6/eh+4oYQ==",
       "dev": true
     },
     "bitmovin-player-ui": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.1",
-    "bitmovin-player": "^8.165.0",
-    "bitmovin-player-ui": "^3.3.1",
+    "bitmovin-player": "^8.192.1-beta.0",
+    "bitmovin-player-ui": "^3.75.0",
     "changelog-parser": "^3.0.1",
     "create-file-webpack": "^1.0.2",
     "husky": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.1",
-    "bitmovin-player": "^8.192.1-beta.0",
-    "bitmovin-player-ui": "^3.75.0",
+    "bitmovin-player": "~8.158.1",
+    "bitmovin-player-ui": "^3.55.0",
     "changelog-parser": "^3.0.1",
     "create-file-webpack": "^1.0.2",
     "husky": "^8.0.3",
@@ -53,6 +53,6 @@
   },
   "peerDependencies": {
     "@convivainc/conviva-js-coresdk": "^4.7.6",
-    "bitmovin-player": "^8.165.0"
+    "bitmovin-player": "~8.158.1"
   }
 }

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -290,6 +290,13 @@ export class PlayerEventHelper {
     });
   }
 
+  fireRestoringContentEvent(): void {
+    this.fireEvent<PlayerEventBase>({
+      timestamp: Date.now(),
+      type: PlayerEvent.RestoringContent,
+    });
+  }
+
   fireAdBreakFinishedEvent(): void {
     this.fireEvent<AdBreakEvent>({
       timestamp: Date.now(),

--- a/spec/helper/PlayerEvent.ts
+++ b/spec/helper/PlayerEvent.ts
@@ -494,9 +494,10 @@ export enum PlayerEvent {
    * @since v7.5.4
    */
   AdBreakStarted = 'adbreakstarted',
+
   /**
-   * Is fired when the playback of an ad break has ended. Is preceded by a @see {@link AdBreakStarted} event.
-   * This event is currently only supported for the ad client typ 'ima'.
+   * Is fired when the playback of an ad break has ended and the main content has been restored. Is preceded by a
+   * @see {@link AdBreakStarted} event.
    * The passed event is of type {@link AdBreakEvent}.
    *
    * Also accessible via the bitmovin.player.PlayerEvent.AdBreakFinished constant.
@@ -505,6 +506,15 @@ export enum PlayerEvent {
    * @since v7.5.4
    */
   AdBreakFinished = 'adbreakfinished',
+
+  /**
+   * Is fired when the playback of an break has finished and the player is about to start restoring the main content.
+   * Is succeeded by a @see {@link AdBreakStarted} event once the main content has been restored.
+   *
+   * @event
+   * @since v8.192.1
+   */
+  RestoringContent = 'restoringcontent',
   /**
    * Is fired when the playback of an ad has been finished.
    * The passed event is of type {@link AdEvent}.

--- a/spec/helper/PlayerEvent.ts
+++ b/spec/helper/PlayerEvent.ts
@@ -509,10 +509,10 @@ export enum PlayerEvent {
 
   /**
    * Is fired when the playback of an break has finished and the player is about to start restoring the main content.
-   * Is succeeded by a @see {@link AdBreakStarted} event once the main content has been restored.
+   * Is succeeded by a {@link AdBreakFinished} event once the main content has been restored.
    *
    * @event
-   * @since v8.192.1
+   * @since v8.158.1
    */
   RestoringContent = 'restoringcontent',
   /**

--- a/spec/tests/ConvivaAnalytics.spec.ts
+++ b/spec/tests/ConvivaAnalytics.spec.ts
@@ -522,6 +522,20 @@ describe(ConvivaAnalytics, () => {
           Conviva.Constants.ErrorSeverity.WARNING
         );
       })
+
+      it('reports ad break ended when restoring content', () => {
+        playerEventHelper.fireRestoringContentEvent();
+
+        expect(MockHelper.latestVideoAnalytics.reportAdBreakEnded).toHaveBeenCalledTimes(1);
+      });
+
+      it('reports the playback metric on ad finished', () => {
+        (MockHelper.latestVideoAnalytics.reportPlaybackMetric as jest.Mock).mockReset();
+
+        playerEventHelper.fireAdBreakFinishedEvent();
+
+        expect(MockHelper.latestVideoAnalytics.reportPlaybackMetric).toHaveBeenCalledTimes(1);
+      });
     });
   })
 

--- a/spec/tests/ConvivaAnalyticsTracker.spec.ts
+++ b/spec/tests/ConvivaAnalyticsTracker.spec.ts
@@ -77,6 +77,40 @@ describe(ConvivaAnalyticsTracker, () => {
     expect(invokedTimesAfter).toBe(invokedTimesBefore);
   })
 
+  it('should report ad break ended on RestoringContent event', () => {
+    const { playerMock, playerEventHelper } = MockHelper.createPlayerMock();
+    const convivaAnalyticsTracker = new ConvivaAnalyticsTracker('test-key');
+
+    convivaAnalyticsTracker.attachPlayer(playerMock);
+    playerEventHelper.firePlayEvent();
+    convivaAnalyticsTracker.trackRestoringContent();
+
+    expect(MockHelper.latestVideoAnalytics.reportAdBreakEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not report the player state on AdBreakFinished events if there is still an active ad', () => {
+    const { playerMock, playerEventHelper } = MockHelper.createPlayerMock();
+    const convivaAnalyticsTracker = new ConvivaAnalyticsTracker('test-key');
+
+    convivaAnalyticsTracker.attachPlayer(playerMock);
+    playerEventHelper.fireAdBreakFinishedEvent();
+    convivaAnalyticsTracker.trackAdBreakFinished();
+
+    expect(MockHelper.latestVideoAnalytics.reportPlaybackMetric).not.toHaveBeenCalled();
+  });
+
+  it('should report the player state on AdBreakFinished events if there is no active ad', () => {
+    const { playerMock, playerEventHelper } = MockHelper.createPlayerMock();
+    const convivaAnalyticsTracker = new ConvivaAnalyticsTracker('test-key');
+
+    convivaAnalyticsTracker.attachPlayer(playerMock);
+    playerEventHelper.firePlayEvent();
+    convivaAnalyticsTracker.trackRestoringContent();
+    convivaAnalyticsTracker.trackAdBreakFinished();
+
+    expect(MockHelper.latestVideoAnalytics.reportPlaybackMetric).toHaveBeenCalled();
+  });
+
   describe('trackPlaybackStateChanged', () => {
     let convivaAnalyticsTracker: ConvivaAnalyticsTracker;
 
@@ -112,7 +146,6 @@ describe(ConvivaAnalyticsTracker, () => {
       PlayerEvent.StallEnded,
       PlayerEvent.PlaybackFinished,
       PlayerEvent.AdStarted,
-      PlayerEvent.AdBreakFinished,
     ])('should clear timer for stalling when reported player event is %s', (event) => {
       const stallTrackingStopTimeoutSpy = jest.spyOn(convivaAnalyticsTracker['stallTrackingTimeout'], 'clear');
 

--- a/spec/tests/ConvivaAnalyticsTracker.spec.ts
+++ b/spec/tests/ConvivaAnalyticsTracker.spec.ts
@@ -2,7 +2,6 @@ import { PlayerEvent, PlayerEventBase } from "bitmovin-player";
 import { ConvivaAnalyticsTracker } from "../../src/ts/ConvivaAnalyticsTracker";
 import { MockHelper } from "../helper/MockHelper";
 import * as Conviva from '@convivainc/conviva-js-coresdk';
-import { PlayerStateHelper } from "../../src/ts/helper/PlayerStateHelper";
 
 jest.mock('@convivainc/conviva-js-coresdk', () => {
   const { MockHelper } = jest.requireActual('../helper/MockHelper');
@@ -122,117 +121,6 @@ describe(ConvivaAnalyticsTracker, () => {
       expect(stallTrackingStopTimeoutSpy).toHaveBeenCalled();
     })
   })
-
-  /**
-   * Since the web player dispatches AdBreakFinished only after main content has successfully restored,
-   * a workaround is in place to signal the end of the ad break early so that VST can properly be tracked.
-   */
-  describe('eager ad break ended signalling', () => {
-    let convivaAnalyticsTracker: ConvivaAnalyticsTracker;
-    let reportAdBreakEndedSpy: jest.SpyInstance;
-    let reportAdBreakStartedSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      convivaAnalyticsTracker = new ConvivaAnalyticsTracker('test-key');
-
-      const {playerMock} = MockHelper.createPlayerMock();
-      convivaAnalyticsTracker.attachPlayer(playerMock);
-      jest.spyOn(playerMock, 'getSource').mockImplementation(() => ({ title: 'test-title' }));
-      convivaAnalyticsTracker.initializeSession();
-      
-      jest.useFakeTimers();
-      reportAdBreakEndedSpy = jest.spyOn(convivaAnalyticsTracker['convivaVideoAnalytics'], 'reportAdBreakEnded');
-      reportAdBreakStartedSpy = jest.spyOn(convivaAnalyticsTracker['convivaVideoAnalytics'], 'reportAdBreakStarted');
-    });
-
-    it('should report ad break ended on AdBreakFinished by default', () => {
-      convivaAnalyticsTracker.trackAdBreakStarted(Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdStarted({}, Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdFinished();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(0);
-
-      convivaAnalyticsTracker.trackAdBreakFinished();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(1);
-    })
-
-    it('should report ad break ended early if AdBreakFinished is too slow', () => {
-      convivaAnalyticsTracker.trackAdBreakStarted(Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdStarted({}, Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdFinished();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(0);
-
-      jest.runAllTimers();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(1);
-    })
-
-    it('should not report ad break ended twice if AdBreakFinished is emitted after the ad finished timer has already expired', () => {
-      convivaAnalyticsTracker.trackAdBreakStarted(Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdStarted({}, Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdFinished();
-
-      jest.runAllTimers();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(1);
-
-      convivaAnalyticsTracker.trackAdBreakFinished();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(1);
-    })
-
-    it('should not report ad break ended if AdFinished is followed by a new AdStarted', () => {
-      convivaAnalyticsTracker.trackAdBreakStarted(Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdStarted({}, Conviva.Constants.AdType.CLIENT_SIDE);
-
-      expect(reportAdBreakStartedSpy).toHaveBeenCalledTimes(1);
-
-      convivaAnalyticsTracker.trackAdFinished();
-      convivaAnalyticsTracker.trackAdStarted({}, Conviva.Constants.AdType.CLIENT_SIDE);
-
-      jest.runAllTimers();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(0);
-      expect(reportAdBreakStartedSpy).toHaveBeenCalledTimes(1);
-    })
-
-    it('should report ad break started again after wrongly reporting ad break ended', () => {
-      convivaAnalyticsTracker.trackAdBreakStarted(Conviva.Constants.AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdStarted({}, Conviva.Constants.AdType.CLIENT_SIDE);
-
-      expect(reportAdBreakStartedSpy).toHaveBeenCalledTimes(1);
-
-      convivaAnalyticsTracker.trackAdFinished();
-      jest.runAllTimers();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(1);
-
-      convivaAnalyticsTracker.trackAdStarted({}, Conviva.Constants.AdType.CLIENT_SIDE);
-
-      expect(reportAdBreakStartedSpy).toHaveBeenCalledTimes(2);
-    })
-
-    it('should only signal that playback has resumed after the actual AdBreakFinished', () => {
-      const { AdType, Playback, PlayerState } = Conviva.Constants;
-      const reportPlaybackSpy = jest.spyOn(convivaAnalyticsTracker['convivaVideoAnalytics'], 'reportPlaybackMetric');
-      jest.spyOn(PlayerStateHelper, 'getPlayerState').mockReturnValue(PlayerState.PLAYING);
-
-      convivaAnalyticsTracker.trackAdBreakStarted(AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdStarted({}, AdType.CLIENT_SIDE);
-      convivaAnalyticsTracker.trackAdFinished();
-
-      jest.runAllTimers();
-
-      expect(reportAdBreakEndedSpy).toHaveBeenCalledTimes(1);
-      expect(reportPlaybackSpy).not.toHaveBeenCalledWith(Playback.PLAYER_STATE, PlayerState.PLAYING);
-
-      convivaAnalyticsTracker.trackAdBreakFinished();
-
-      expect(reportPlaybackSpy).toHaveBeenCalledWith(Playback.PLAYER_STATE, PlayerState.PLAYING);
-    })
-  });
 })
 
 const getInvokedTimes = (mock: unknown) => {

--- a/spec/tests/PlayerEvents.spec.ts
+++ b/spec/tests/PlayerEvents.spec.ts
@@ -269,17 +269,20 @@ describe('player event tests', () => {
 
       it('on adError', () => {
         playerEventHelper.fireAdErrorEvent();
+        playerEventHelper.fireRestoringContentEvent();
         playerEventHelper.fireAdBreakFinishedEvent();
         expect(MockHelper.latestVideoAnalytics.reportAdBreakEnded).toHaveBeenCalledTimes(1);
       });
 
       it('on ad skipped', () => {
         playerEventHelper.fireAdSkippedEvent();
+        playerEventHelper.fireRestoringContentEvent();
         playerEventHelper.fireAdBreakFinishedEvent();
         expect(MockHelper.latestVideoAnalytics.reportAdBreakEnded).toHaveBeenCalledTimes(1);
       });
 
       it('on ad end', () => {
+        playerEventHelper.fireRestoringContentEvent();
         playerEventHelper.fireAdBreakFinishedEvent();
         expect(MockHelper.latestVideoAnalytics.reportAdBreakEnded).toHaveBeenCalledTimes(1);
       });

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -299,10 +299,14 @@ export class ConvivaAnalytics {
   };
 
   private onRestoringContent = (event: PlayerEventBase) => {
-    this.debugLog('[ ConvivaAnalytics ] [ Player Event ] adbreak finished, restoring content', event);
-    this.convivaAnalyticsTracker.trackAdBreakFinished();
-    this.convivaAnalyticsTracker.trackPlaybackStateChanged(event);
+    this.debugLog('[ ConvivaAnalytics ] [ Player Event ] restoring content', event);
+    this.convivaAnalyticsTracker.trackRestoringContent();
   };
+
+  private onAdBreakFinished = (event: AdBreakEvent) => {
+    this.debugLog('[ ConvivaAnalytics ] [ Player Event ] adbreak finished', event);
+    this.convivaAnalyticsTracker.trackAdBreakFinished();
+  }
 
   private onAdError = (event: ErrorEvent) => {
     this.debugLog('[ ConvivaAnalytics ] [ Player Event ] ad error', event);
@@ -376,6 +380,7 @@ export class ConvivaAnalytics {
     this.handlers.add(PlayerEvent.AdFinished, this.onAdFinished);
     this.handlers.add(PlayerEvent.AdBreakStarted, this.onAdBreakStarted);
     this.handlers.add(PlayerEvent.RestoringContent, this.onRestoringContent);
+    this.handlers.add(PlayerEvent.AdBreakFinished, this.onAdBreakFinished);
     this.handlers.add(PlayerEvent.AdSkipped, this.onAdSkipped);
     this.handlers.add(PlayerEvent.AdError, this.onAdError);
     this.handlers.add(PlayerEvent.Error, this.onError);

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -298,8 +298,8 @@ export class ConvivaAnalytics {
     this.onCustomEvent(event);
   };
 
-  private onAdBreakFinished = (event: AdBreakEvent) => {
-    this.debugLog('[ ConvivaAnalytics ] [ Player Event ] adbreak finished', event);
+  private onRestoringContent = (event: PlayerEventBase) => {
+    this.debugLog('[ ConvivaAnalytics ] [ Player Event ] adbreak finished, restoring content', event);
     this.convivaAnalyticsTracker.trackAdBreakFinished();
     this.convivaAnalyticsTracker.trackPlaybackStateChanged(event);
   };
@@ -375,7 +375,7 @@ export class ConvivaAnalytics {
     this.handlers.add(PlayerEvent.AdStarted, this.onAdStarted);
     this.handlers.add(PlayerEvent.AdFinished, this.onAdFinished);
     this.handlers.add(PlayerEvent.AdBreakStarted, this.onAdBreakStarted);
-    this.handlers.add(PlayerEvent.AdBreakFinished, this.onAdBreakFinished);
+    this.handlers.add(PlayerEvent.RestoringContent, this.onRestoringContent);
     this.handlers.add(PlayerEvent.AdSkipped, this.onAdSkipped);
     this.handlers.add(PlayerEvent.AdError, this.onAdError);
     this.handlers.add(PlayerEvent.Error, this.onError);

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -623,6 +623,7 @@ export class ConvivaAnalyticsTracker {
       PlayerEvent.TimeShift,
       PlayerEvent.AdBreakStarted,
       PlayerEvent.AdFinished,
+      PlayerEvent.RestoringContent,
     ];
     const stallTrackingClearEvents = [
       PlayerEvent.StallStarted, // StallStarted is reported as BUFFERING immediately. Does not need the delayed timeout approach.
@@ -633,7 +634,6 @@ export class ConvivaAnalyticsTracker {
       PlayerEvent.StallEnded,
       PlayerEvent.PlaybackFinished,
       PlayerEvent.AdStarted,
-      PlayerEvent.AdBreakFinished,
     ];
 
     if (stallTrackingStartEvents.indexOf(event.type) !== -1) {

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -112,9 +112,7 @@ export interface EventAttributes {
 export class ConvivaAnalyticsTracker {
   private static readonly VERSION: string = '{{VERSION}}';
 
-  public static readonly AD_BREAK_FINISHED_DELAY_MS = 250;
   public static readonly STALL_TRACKING_DELAY_MS = 100;
-
   private _player: PlayerAPI;
 
   private get player(): PlayerAPI {
@@ -724,7 +722,7 @@ export class ConvivaAnalyticsTracker {
   };
 
   public trackAdBreakStarted = (type: Conviva.valueof<Conviva.ConvivaConstants['AdType']>) => {
-    if (!this.isSessionActive()) {
+    if (!this.isSessionActive() || this._isAdBreakActive) {
       return;
     }
 
@@ -738,17 +736,8 @@ export class ConvivaAnalyticsTracker {
   };
 
   public trackAdStarted = (adInfo: Conviva.ConvivaMetadata, type: Conviva.valueof<Conviva.ConvivaConstants['AdType']>, bitrateKbps?: number) => {
-    // Clear the timeout that may have been scheduled by a previous ad finished event, as the ad break is not actually over yet.
-    this.adBreakFinishedTimeout.clear();
-
     if (!this.isSessionActive()) {
       return;
-    }
-
-    if (!this.isAdBreakActive) {
-      // If no ad break is active, it must mean that the `adBreakFinishedTimeout` ran before AdStarted was emitted.
-      // Then we need to report this as the start of a new ad break.
-      this.trackAdBreakStarted(type);
     }
 
     this.debugLog('[ ConvivaAnalyticsTracker ] report ad started', {
@@ -780,6 +769,15 @@ export class ConvivaAnalyticsTracker {
     }
   }
 
+  public trackAdFinished = () => {
+    if (!this.isSessionActive()) {
+      return;
+    }
+
+    this.debugLog('[ ConvivaAnalyticsTracker ] report ad ended');
+    this.convivaAdAnalytics.reportAdEnded();
+  }
+
   public trackAdSkipped = () => {
     if (!this.isSessionActive()) {
       return;
@@ -789,39 +787,15 @@ export class ConvivaAnalyticsTracker {
     this.convivaAdAnalytics.reportAdSkipped();
   };
 
-  public trackAdFinished = () => {
+  public trackAdBreakFinished = () => {
     if (!this.isSessionActive()) {
       return;
     }
 
-    this.debugLog('[ ConvivaAnalyticsTracker ] report ad ended');
-    this.convivaAdAnalytics.reportAdEnded();
-
-    // Start timer to report ad break finished, as waiting for the event will cause VST to be too low.
-    this.adBreakFinishedTimeout.start();
-  }
-
-  private reportAdBreakEnded = () => {
     this._isAdBreakActive = false;
 
     this.debugLog('[ ConvivaAnalyticsTracker ] report ad break ended');
     this.convivaVideoAnalytics.reportAdBreakEnded();
-  }
-
-  private adBreakFinishedTimeout = new Timeout(ConvivaAnalyticsTracker.AD_BREAK_FINISHED_DELAY_MS, this.reportAdBreakEnded);
-
-  public trackAdBreakFinished = () => {
-    // Clear the timeout to prevent the ad break finished event from being reported twice
-    this.adBreakFinishedTimeout.clear();
-
-    if (!this.isSessionActive()) {
-      return;
-    }
-
-    if (this.isAdBreakActive) {
-      // If ad break is still active, it must mean that the event was faster than the `adBreakFinishedTimeout`
-      this.reportAdBreakEnded();
-    }
 
     this.debugLog(`[ ConvivaAnalyticsTracker ] report ${PlayerStateHelper.getPlayerState(this.player)} playback state`);
     this.convivaVideoAnalytics.reportPlaybackMetric(

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -787,7 +787,7 @@ export class ConvivaAnalyticsTracker {
     this.convivaAdAnalytics.reportAdSkipped();
   };
 
-  public trackAdBreakFinished = () => {
+  public trackRestoringContent = () => {
     if (!this.isSessionActive()) {
       return;
     }
@@ -796,6 +796,12 @@ export class ConvivaAnalyticsTracker {
 
     this.debugLog('[ ConvivaAnalyticsTracker ] report ad break ended');
     this.convivaVideoAnalytics.reportAdBreakEnded();
+  };
+
+  public trackAdBreakFinished = () => {
+    if (!this.isSessionActive() || this._isAdBreakActive) {
+      return;
+    }
 
     this.debugLog(`[ ConvivaAnalyticsTracker ] report ${PlayerStateHelper.getPlayerState(this.player)} playback state`);
     this.convivaVideoAnalytics.reportPlaybackMetric(


### PR DESCRIPTION
With the changes implemented in 5.4.1, we changed the tracking for ad pods to use a timeout after the `AdFinished` event in an attempt to make the VST measurements more accurate. However, this approach does not work well when multiple ads are being played back, and in case multiple ad breaks are being played back, we incorrectly attributed the time spent between ad breaks to the VST.

In order to make VST tracking more accurate when ads are being played back, we introduced the `PlayerEvent.RestoringContent` event in player version 8.158.1 (and 8.193.0 onwards). This event is used to signal, that the main content is being restored, and the time passing between the `RestoringContent` and `AdBreakFinished` events can, and now is being used to properly determine VST in case of pre-roll ads.

**This change is a breaking change as it requires a newly introduced player event, and therefore also requires a new major release.**

We also added an input to the Release workflow to allow releasing new major versions.