### PR TITLE
Update player version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Update `bitmovin-player` dependency to `^8.193.0`
+  - This is the most recent player version that added the `PlayerEvent.RestoringContent` event
 
 ## [6.0.0] - 2024-12-05
 ### Changed

--- a/example/index.html
+++ b/example/index.html
@@ -33,7 +33,7 @@
         box-shadow: 0 0 30px rgba(0, 0, 0, 0.7);
       }
     </style>
-    <script src="//cdn.bitmovin.com/player/web/8.193.0/bitmovinplayer.js"></script>
+    <script src="//cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
     <script src="./conviva-core-sdk.js"></script>
     <script src="./dist/bitmovin-player-analytics-conviva.js"></script>
   </head>

--- a/example/index.html
+++ b/example/index.html
@@ -33,7 +33,7 @@
         box-shadow: 0 0 30px rgba(0, 0, 0, 0.7);
       }
     </style>
-    <script src="//cdn.bitmovin.com/player/web/8.158.1/bitmovinplayer.js"></script>
+    <script src="//cdn.bitmovin.com/player/web/8.193.0/bitmovinplayer.js"></script>
     <script src="./conviva-core-sdk.js"></script>
     <script src="./dist/bitmovin-player-analytics-conviva.js"></script>
   </head>
@@ -233,7 +233,6 @@
             level: 'debug',
           },
           events: {},
-          advertising: {},
           remotecontrol: {
             receiverApplicationId: 'FE832A8F', // Replace with your application id
             type: 'googlecast',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^24.0.1",
-        "bitmovin-player": "~8.158.1",
-        "bitmovin-player-ui": "^3.55.0",
+        "bitmovin-player": "^8.193.0",
+        "bitmovin-player-ui": "^3.75.0",
         "changelog-parser": "^3.0.1",
         "create-file-webpack": "^1.0.2",
         "husky": "^8.0.3",
@@ -33,7 +33,7 @@
       },
       "peerDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.6",
-        "bitmovin-player": "~8.158.1"
+        "bitmovin-player": "^8.193.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/bitmovin-player": {
-      "version": "8.158.1",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.158.1.tgz",
-      "integrity": "sha512-kbDMNCzyHOJuYOZPiSlJVR5tvsYLQpKFBoLRSnI00ineDU9rrZR0PbOTcHsY5OoRIT/XHxrgRmpVO6/eh+4oYQ==",
+      "version": "8.193.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.193.0.tgz",
+      "integrity": "sha512-zxI3tzZKcP2opac/PhfwyhNp1pMqbzMl/FPWuI0E63DNmvppUVfOhVWAGLNTBIc9sEpbYUPyMBq5XWd7Ml10jw==",
       "dev": true
     },
     "node_modules/bitmovin-player-ui": {
@@ -12391,9 +12391,9 @@
       }
     },
     "bitmovin-player": {
-      "version": "8.158.1",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.158.1.tgz",
-      "integrity": "sha512-kbDMNCzyHOJuYOZPiSlJVR5tvsYLQpKFBoLRSnI00ineDU9rrZR0PbOTcHsY5OoRIT/XHxrgRmpVO6/eh+4oYQ==",
+      "version": "8.193.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.193.0.tgz",
+      "integrity": "sha512-zxI3tzZKcP2opac/PhfwyhNp1pMqbzMl/FPWuI0E63DNmvppUVfOhVWAGLNTBIc9sEpbYUPyMBq5XWd7Ml10jw==",
       "dev": true
     },
     "bitmovin-player-ui": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.1",
-    "bitmovin-player": "~8.158.1",
-    "bitmovin-player-ui": "^3.55.0",
+    "bitmovin-player": "^8.193.0",
+    "bitmovin-player-ui": "^3.75.0",
     "changelog-parser": "^3.0.1",
     "create-file-webpack": "^1.0.2",
     "husky": "^8.0.3",
@@ -53,6 +53,6 @@
   },
   "peerDependencies": {
     "@convivainc/conviva-js-coresdk": "^4.7.6",
-    "bitmovin-player": "~8.158.1"
+    "bitmovin-player": "^8.193.0"
   }
 }

--- a/spec/helper/PlayerEvent.ts
+++ b/spec/helper/PlayerEvent.ts
@@ -512,7 +512,7 @@ export enum PlayerEvent {
    * Is succeeded by a {@link AdBreakFinished} event once the main content has been restored.
    *
    * @event
-   * @since v8.158.1
+   * @since v8.193.0
    */
   RestoringContent = 'restoringcontent',
   /**


### PR DESCRIPTION
This PR bumps the player version to 8.193.0, as the `PlayerEvent.RestoringContent` event introduced together with https://github.com/bitmovin/bitmovin-player-web-analytics-conviva/pull/119 was forward-ported to this player version.