### PR TITLE
fix: Correct streamType override logic in getStreamType

### DIFF
--- a/spec/tests/ConvivaAnalytics.spec.ts
+++ b/spec/tests/ConvivaAnalytics.spec.ts
@@ -277,6 +277,30 @@ describe(ConvivaAnalytics, () => {
           );
         });
 
+        it('streamType override to VOD is respected on live stream', () => {
+          jest.spyOn(playerMock, 'isLive').mockReturnValue(true);
+          convivaAnalytics.updateContentMetadata({ streamType: Conviva.ContentMetadata.StreamType.VOD });
+          playerEventHelper.firePlayEvent();
+          expect(MockHelper.latestVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              isLive: Conviva.ContentMetadata.StreamType.VOD,
+              streamType: Conviva.ContentMetadata.StreamType.VOD,
+            }),
+          );
+        });
+
+        it('streamType override to LIVE is respected on VOD stream', () => {
+          jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+          convivaAnalytics.updateContentMetadata({ streamType: Conviva.ContentMetadata.StreamType.LIVE });
+          playerEventHelper.firePlayEvent();
+          expect(MockHelper.latestVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              isLive: Conviva.ContentMetadata.StreamType.LIVE,
+              streamType: Conviva.ContentMetadata.StreamType.LIVE,
+            }),
+          );
+        });
+
         it('applicationname', () => {
           convivaAnalytics.updateContentMetadata({ applicationName: 'someValue' });
           playerEventHelper.firePlayEvent();

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -594,9 +594,10 @@ export class ConvivaAnalyticsTracker {
 
   private getStreamType(): Conviva.valueof<Conviva.ConvivaConstants['StreamType']> {
     const overrides = this.contentMetadataBuilder.getOverrides();
-    return overrides.streamType || this.player.isLive()
-      ? Conviva.ContentMetadata.StreamType.LIVE
-      : Conviva.ContentMetadata.StreamType.VOD;
+    if (overrides.streamType !== undefined) {
+      return overrides.streamType;
+    }
+    return this.player.isLive() ? Conviva.ContentMetadata.StreamType.LIVE : Conviva.ContentMetadata.StreamType.VOD;
   }
 
   private internalEndSession = () => {


### PR DESCRIPTION
Fixed operator precedence issue where the streamType override from updateContentMetadata was not being respected. Added tests to verify streamType can be overridden from LIVE to VOD and vice versa.