### PR TITLE
feature: Add support for setting custom and required metadata separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,174 +7,247 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `updateRequiredContentMetadata` and `updateCustomContentMetadata` methods
+  - Allows Conviva-managed metadata such as `streamType` to be configured separately from custom metadata
+  - Allows custom metadata keys such as `streamType` to override internally populated custom tags without affecting Conviva's required `streamType`
+
 ## [6.1.5] - 2026-02-25
+
 ### Fixed
+
 - `streamType` override not correctly respected
 
 ## [6.1.3] - 2025-11-06
+
 ### Fixed
+
 - Support for streamType override in `updateContentMetadata`
 
 ## [6.1.2] - 2024-12-24
+
 ### Fixed
+
 - Delayed buffering reporting on CSAI events
 - Reporting of ad break ended for SSAI ads
 
 ## [6.1.1] - 2024-12-19
+
 ### Fixed
+
 - Mid-roll ads erroneously reported as post-rolls when mid-roll's schedule time is greater than the duration of the ad
 
 ## [6.1.0] - 2024-12-11
+
 ### Changed
+
 - Update `bitmovin-player` dependency to `^8.193.0`
   - This is the most recent player version that added the `PlayerEvent.RestoringContent` event
 
 ## [6.0.0] - 2024-12-05
+
 ### Changed
+
 - Update `bitmovin-player` dependency to `~8.158.1`
   - Necessary due to dependency on newly introduced `PlayerEvent.RestoringContent` event
 
 ### Fixed
+
 - Overreported VST after playing CSAI pre-rolls
 
 ## [5.4.1] - 2024-11-27
+
 ### Fixed
+
 - Ad-related delays not contributing to rebuffering metrics
 - Underreported VST after playing CSAI pre-rolls
 
 ## [5.4.0] - 2024-08-27
+
 ### Added
+
 - Possibility to start session tracking without a `Player` instance
   - `const convivaAnalytics = new ConvivaAnalytics(undefined, customerKey)` initializer without a `Player`
   - `convivaAnalytics.attachPlayer(player)` to attach the `Player` at a later point in the session life-cycle
 
 ## [5.3.0] - 2024-08-14
+
 ### Changed
+
 - Track initial audio track and subtitles only after the first `Play` event
 
 ## [5.2.0] - 2024-07-08
+
 ### Added
+
 - Server side ad tracking
   - It is exposed via `ConvivaAnalytics.ssai`
   - An example can be found in `examples/index.html`
 
 ## [5.1.0] - 2024-06-13
+
 ### Added
+
 - Basic client ad tracking using `Conviva.AdAnalytics`
 
 ### Changed
+
 - Update `bitmovin-player` dependency to `^8.165.0`
 
 ## [5.0.0] - 2024-05-21
+
 ### Added
+
 - Send player info metadata (framework and framework version)
 - `additionalStandardTags` to `Metadata` of `updateContentMetadata` for [Conviva pre-defined video and content metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/javascript/js_quick_integration.htm)
 
 ### Changed
+
 - Updated Conviva types to the latest version and fixed some type issues
 
 ### Removed
+
 - `framework` and `frameworkVersion` custom metadata fields (custom tags)
 - `CustomContentMetadata`, use `Metadata['custom']` instead
 
 ## [4.2.0] - 2023-08-24
+
 ### Added
+
 - Support for Conviva-SDK version 4.7.0
 - Tracking for Audio language
 - Tracking for Subtitle Language
 - Tracking for Closed Caption Language
 
 ### Removed
+
 - Support for Conviva-SDK version 4.6.1
 
 ## [4.1.0] - 2022-10-24
+
 ### Added
+
 - Support for Conviva-SDK version 4.5.7
 
 ### Removed
+
 - Support for Conviva-SDK version 4.0.15
 
 ### Fixed
+
 - Consecutive playback of multiple sources not tracked correctly
 
 ## [4.0.3] - 2021-04-30
+
 ### Added
+
 - `bitmovin-player@^8.31.0` as peer dependency.
 - Possibility to set detailed Conviva Device Metadata via `ConvivaAnalyticsConfiguration.deviceMetadata`
 - Possibility to override values for internally set custom metdata keys `streamType`, `playerType` and `vrContentType`
 
 ### Deprecated
+
 - `ConvivaAnalyticsConfiguration.deviceCategory` field in favour of `ConvivaAnalyticsConfiguration.deviceMetadata.category` field
 
 ## [4.0.2] - 2021-02-24
+
 ### Fixed
+
 - Metadata was cleared after playback finished.
 
 ## [4.0.1] - 2021-02-01
+
 ### Fixed
+
 - Uncaught TypeError (`Cannot read property 'release' of null`) when attempting to release the Conviva instance.
 
 ## [4.0.0] - 2021-01-15
+
 ### Added
+
 - Support for Conviva-SDK 4.0.15.
 
 ### Removed
+
 - Support for Conviva-SDK 2.151.0.36981.
 
 ## [3.0.6] - 2020-04-16
+
 ### Fixed
+
 - Prefer `window.setInterval()` in `Html5Timer.ts` instead of the NodeJS definition.
 
 ## [3.0.5] - 2020-03-30
+
 ### Fixed
+
 - Updated `webpack-dev-server` to the latest version, to resolve console errors when running locally via `npm run start`.
 
 ## [3.0.4] - 2020-03-05
+
 ### Fixed
+
 - Send playing event after an ad break has finished.
 
 ## [3.0.3] - 2020-02-05
+
 ### Added
+
 - Added a configuration option to set the Conviva Device Category.
 
 ## [3.0.2] - 2019-10-23
+
 ### Added
+
 - `endSession` will now prevent a new session from being initialized via internal event handling.
 
 ## [3.0.1] - 2019-05-16
+
 ### Added
+
 - Support for Conviva-SDK 2.151.0.36981.
 
 ## [3.0.0] - 2019-03-15
+
 ### Added
+
 - `initializeSession` to external start session.
 - `endSession` to external end session.
 - `updateContentMetadata` to update content metadata after initializing.`ConvivaAnalytics`
 - Support for Player v8 events.
 
 ### Changed
+
 - Update to Bitmovin Player v8 API.
 - Switch to Webpack.
 - Improve typings.
 
 ### Removed
+
 - `viewerId`, `applicationName` and `customTags` from `ConvivaAnalyticsConfiguration`. Use `updateContentMetadata` instead.
 
 ## [2.1.0] - 2019-01-17
+
 ### Added
+
 - `integrationVersion` as custom `contentMetadata` attribute
 - Method to track custom deficiency events
 
 ## 2.0.0 - 2018-12-13
+
 ### Added
+
 - Tracking of `autoplay` and `preload` config attributes.
 - Live stream support.
 
 ### Changed
+
 - Updated Conviva-SDK to 2.146.0.36444.
 - Bind `PlayerStateManager`'s lifecycle to the lifecycle of the `Client`.
 
 ### Removed
+
 - Seek event tracking
 
 [Unreleased]: https://github.com/bitmovin/bitmovin-player-analytics-conviva/compare/v6.1.5...HEAD

--- a/README.md
+++ b/README.md
@@ -1,142 +1,173 @@
 # Bitmovin Player Conviva Analytics Integration
+
 This is an open-source project to enable the use of a third-party component (Conviva) with the Bitmovin Player Web SDK.
 
 ## Maintenance and Update
+
 This project is not part of a regular maintenance or update schedule and is updated once yearly to conform with the latest product versions. For additional update requests, please take a look at the guidance further below.
 
 ## Contributions to this project
+
 As an open-source project, we are pleased to accept any and all changes, updates and fixes from the community wishing to use this project. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more details on how to contribute.
 
 ## Reporting player bugs
+
 If you come across a bug related to the player, please raise this through your support ticketing system.
 
 ## Need more help?
+
 Should you want some help updating this project (update, modify, fix or otherwise) and cant contribute for any reason, please raise your request to your bitmovin account team, who can discuss your request.
 
 ## Support and SLA Disclaimer
+
 As an open-source project and not a core product offering, any request, issue or query related to this project is excluded from any SLA and Support terms that a customer might have with either Bitmovin or another third-party service provider or Company contributing to this project. Any and all updates are purely at the contributor's discretion.
 
 Thank you for your contributions!
 
 ## Compatibility
-**This version of the Conviva Analytics Integration works only with Player Version >= 8.31.x.
+
+**This version of the Conviva Analytics Integration works only with Player Version >= 8.31.x.**
 The recommended and tested version of the Conviva SDK is 4.5.7. See [CHANGELOG.md](CHANGELOG.md) for details.
 
 ## Getting Started
+
 ### Installation
+
 #### Using NPM
+
 Install the npm package:
+
 ```
 npm i @bitmovin/player-integration-conviva --save-dev
 ```
 
 #### Using custom build
+
 Build the JS file by running `npm run build`
 
 ### Developing
+
 1. Clone Git repository
 2. Install node.js
 3. Install required npm packages: [`npm install`](https://www.npmjs.com/)
 4. Run tasks:
-  * `npm run lint` to lint TypeScript files as well as CHANGELOG.md
-  * `npm run build` to build project into `dist` directory
-  * `npm run start` to open test page in browser, build and reload changed files automatically
-  * `npm run format` to run prettier and auto-format all code files
-  * `npm run test` to run tests
+
+- `npm run lint` to lint TypeScript files as well as CHANGELOG.md
+- `npm run build` to build project into `dist` directory
+- `npm run start` to open test page in browser, build and reload changed files automatically
+- `npm run format` to run prettier and auto-format all code files
+- `npm run test` to run tests
 
 ## Usage
+
 1. Include `conviva-core-sdk.min.js` as **first** of all scripts in your HTML document
 
 1. Create an instance of `ConvivaAnalytics` **before** calling `player.load(...)` and pass in your Conviva `CUSTOMER_KEY` and optional configuration properties:
 
-    1. Using NPM import:
-        1. Import ConvivaAnalytics:
-            ```typescript
-            import { ConvivaAnalytics } from '@bitmovin/player-integration-conviva';
-            ```
+   1. Using NPM import:
 
-        1. Usage
-            ```typescript
-            const playerConfig = {
-              key: 'YOUR-PLAYER-KEY',
-              // ...
-            };
+      1. Import ConvivaAnalytics:
 
-            const player = new Player(document.getElementById('player'), playerConfig);
-            const conviva = new ConvivaAnalytics(player, 'CUSTOMER_KEY', {
-              debugLoggingEnabled: true, // optional
-              gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // optional, TOUCHSTONE_SERVICE_URL for testing
-              deviceCategory: Conviva.Client.DeviceCategory.WEB, // optional, deprecated (Use deviceMetadata.category) (default: WEB)
-              deviceMetadata: { // optional (default: let Conviva backend infer these fields from User Agent sring)
-                category: Conviva.Client.DeviceCategory.WEB, // optional (default: WEB)
-                brand: 'Device brand', // optional
-                manufacturer: 'Device Manufacturer', // optional
-                model: 'Device Model', // optional
-                type: Conviva.Client.DeviceType.DESKTOP, // optional
-                version: 'Device version', // optional
-                osName: 'Operating system name', // optional
-                osVersion: 'Operating system version' // optional
-              }
-            });
-            
-            var sourceConfig = {
-              // ...
-            };
-                        
-            player.load(sourceConfig).then(function() {
-              console.log('player loaded');
-            }, function(reason) {
-              console.error('player setup failed', reason);
-            });
-            ```
-    
-    2. Using custom Build:
-        1. Include `bitmovinplayer-analytics-conviva.js` **after** `conviva-core-sdk.min.js` in your HTML document
+         ```typescript
+         import { ConvivaAnalytics } from '@bitmovin/player-integration-conviva';
+         ```
 
-        2. Usage
-            ```js
-            var playerConfig = {
-              key: 'YOUR-PLAYER-KEY',
-              // ...
-            };
-        
-            var container = document.getElementById('player');
-            var player = new bitmovin.player.Player(container, playerConfig);
-            
-            // A ConvivaAnalytics instance is always tied to one player instance
-            var conviva = new bitmovin.player.analytics.ConvivaAnalytics(player, 'CUSTOMER_KEY', {
-              debugLoggingEnabled: true, // optional
-              gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // optional, TOUCHSTONE_SERVICE_URL for testing
-              deviceCategory: Conviva.Client.DeviceCategory.WEB // optional, (default: WEB)
-            });
-            
-            var sourceConfig = {
-              // ...
-            };
-            
-            player.load(sourceConfig).then(function() {
-              console.log('player loaded');
-            }, function(reason) {
-              console.error('player setup failed', reason);
-            });
-            ```
+      1. Usage
 
-2. Release the instance by calling `conviva.release()` before destroying the player by calling `player.destroy()`
- 
+         ```typescript
+         const playerConfig = {
+           key: 'YOUR-PLAYER-KEY',
+           // ...
+         };
+
+         const player = new Player(document.getElementById('player'), playerConfig);
+         const conviva = new ConvivaAnalytics(player, 'CUSTOMER_KEY', {
+           debugLoggingEnabled: true, // optional
+           gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // optional, TOUCHSTONE_SERVICE_URL for testing
+           deviceCategory: Conviva.Client.DeviceCategory.WEB, // optional, deprecated (Use deviceMetadata.category) (default: WEB)
+           deviceMetadata: {
+             // optional (default: let Conviva backend infer these fields from User Agent string)
+             category: Conviva.Client.DeviceCategory.WEB, // optional (default: WEB)
+             brand: 'Device brand', // optional
+             manufacturer: 'Device Manufacturer', // optional
+             model: 'Device Model', // optional
+             type: Conviva.Client.DeviceType.DESKTOP, // optional
+             version: 'Device version', // optional
+             osName: 'Operating system name', // optional
+             osVersion: 'Operating system version', // optional
+           },
+         });
+
+         var sourceConfig = {
+           // ...
+         };
+
+         player.load(sourceConfig).then(
+           function () {
+             console.log('player loaded');
+           },
+           function (reason) {
+             console.error('player setup failed', reason);
+           },
+         );
+         ```
+
+   2. Using custom Build:
+
+      1. Include `bitmovinplayer-analytics-conviva.js` **after** `conviva-core-sdk.min.js` in your HTML document
+
+      2. Usage
+
+         ```js
+         var playerConfig = {
+           key: 'YOUR-PLAYER-KEY',
+           // ...
+         };
+
+         var container = document.getElementById('player');
+         var player = new bitmovin.player.Player(container, playerConfig);
+
+         // A ConvivaAnalytics instance is always tied to one player instance
+         var conviva = new bitmovin.player.analytics.ConvivaAnalytics(player, 'CUSTOMER_KEY', {
+           debugLoggingEnabled: true, // optional
+           gatewayUrl: 'https://youraccount-test.testonly.conviva.com', // optional, TOUCHSTONE_SERVICE_URL for testing
+           deviceCategory: Conviva.Client.DeviceCategory.WEB, // optional, (default: WEB)
+         });
+
+         var sourceConfig = {
+           // ...
+         };
+
+         player.load(sourceConfig).then(
+           function () {
+             console.log('player loaded');
+           },
+           function (reason) {
+             console.error('player setup failed', reason);
+           },
+         );
+         ```
+
+1. Release the instance by calling `conviva.release()` before destroying the player by calling `player.destroy()`
+
 ### Advanced Usage
+
 #### VPF tracking
-If you would like to track custom VPF (Video Playback Failures) events when no actual player error happens (e.g. 
+
+If you would like to track custom VPF (Video Playback Failures) events when no actual player error happens (e.g.
 the server closes the connection and return `net::ERR_EMPTY_RESPONSE` or after a certain time of stalling)
 you can use following API to track those deficiencies.
 
 ```js
 conviva.reportPlaybackDeficiency('Some Error Message', Conviva.Client.ErrorSeverity.FATAL);
 ```
+
 _See [ConvivaAnalytics.ts](./src/ts/ConvivaAnalytics.ts) for parameter details._
 
 Conviva suggests an timeout of about ~10 seconds and before reporting an error to conviva and providing feedback the user.
 
 #### Content Metadata handling
+
 If you want to override some content metadata attributes you can do so by adding the following:
 
 ```js
@@ -153,7 +184,7 @@ let metadataOverrides = {
     'c3.cm.brand': 'Test Brand',
   },
   encodedFrameRate: 24,
-  // … 
+  // …
 };
 
 // …
@@ -167,17 +198,40 @@ Those values will be cleaned up after the session is closed.
 
 _See [ConvivaAnalytics.ts](./src/ts/ConvivaAnalytics.ts) for details about more attributes._
 
+If you need to configure Conviva-managed metadata separately from custom metadata, use the dedicated APIs:
+
+```js
+conviva.updateRequiredContentMetadata({
+  assetName: 'My Asset',
+  viewerId: 'uniqueViewerId',
+  streamType: Conviva.ContentMetadata.StreamType.UNKNOWN,
+});
+
+conviva.updateCustomContentMetadata({
+  custom: {
+    streamType: 'dash_vod',
+    customTag: 'customValue',
+  },
+  additionalStandardTags: {
+    'c3.cm.channel': 'Test Channel',
+  },
+});
+```
+
+This is useful when you want to send Conviva's required `streamType` values (`UNKNOWN`, `VOD`, `LIVE`) and also send an arbitrary custom `streamType` tag in parallel.
+
 #### Consecutive playback
+
 If you want to use the same player instance for multiple playback, just load a new source with `player.load(…)`.
 The integration will close the active session.
- 
+
 ```js
 player.load({…});
 ```
 
 #### External VST tracking
 
-If your app needs additional setup steps which should be included in VST tracking, such as DRM token generation, before the `Player` instance can be initialized, 
+If your app needs additional setup steps which should be included in VST tracking, such as DRM token generation, before the `Player` instance can be initialized,
 the `ConvivaAnalytics` can be initialized without a `Player` instance. Once the `Player` instance is created it can be attached.
 
 1. Create the `ConvivaAnalytics` instance with your `customerKey` and configuration.
@@ -189,12 +243,12 @@ const convivaAnalytics = new ConvivaAnalytics(undefined, customerKey);
 2. Conviva requires that the `assetName` is set at session initialization. Therefore ensure that you provide using the metadata overrides **before** initializing the tracking session.
 
 ```typescript
-convivaAnalytics.updateContentMetadata({
+convivaAnalytics.updateRequiredContentMetadata({
   assetName: 'Your Asset Name',
 });
 
 // Initialize tracking session
-convivaAnalytics.initializeSession()
+convivaAnalytics.initializeSession();
 ```
 
 3. Once your `Player` instance is ready attach it to the `ConvivaAnalytics` instance.
@@ -204,4 +258,4 @@ convivaAnalytics.initializeSession()
 
 const player = new bitmovin.player.Player(document.getElementById('player'), getPlayerConfig());
 convivaAnalytics.attachPlayer(player);
-``` 
+```

--- a/spec/tests/ConvivaAnalytics.spec.ts
+++ b/spec/tests/ConvivaAnalytics.spec.ts
@@ -174,6 +174,30 @@ describe(ConvivaAnalytics, () => {
           );
         });
 
+        it('streamType via required content metadata', () => {
+          convivaAnalytics.updateRequiredContentMetadata({
+            streamType: Conviva.Constants.StreamType.UNKNOWN,
+            assetName: 'MyAsset',
+          });
+          convivaAnalytics.initializeSession();
+          expect(MockHelper.latestVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              isLive: 'unknown',
+            }),
+          );
+        });
+
+        it('custom streamType via custom content metadata', () => {
+          convivaAnalytics.updateContentMetadata({ assetName: 'MyAsset' });
+          convivaAnalytics.updateCustomContentMetadata({ custom: { streamType: 'dash_vod' } });
+          convivaAnalytics.initializeSession();
+          expect(MockHelper.latestVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              streamType: 'dash_vod',
+            }),
+          );
+        });
+
         it('applicationname', () => {
           convivaAnalytics.updateContentMetadata({ applicationName: 'someValue', assetName: 'MyAsset' });
           convivaAnalytics.initializeSession();
@@ -297,6 +321,41 @@ describe(ConvivaAnalytics, () => {
             expect.objectContaining({
               isLive: Conviva.ContentMetadata.StreamType.LIVE,
               streamType: Conviva.ContentMetadata.StreamType.LIVE,
+            }),
+          );
+        });
+
+        it('streamType via required content metadata', () => {
+          jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
+          convivaAnalytics.updateRequiredContentMetadata({ streamType: Conviva.ContentMetadata.StreamType.UNKNOWN });
+          playerEventHelper.firePlayEvent();
+          expect(MockHelper.latestVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              isLive: 'unknown',
+            }),
+          );
+        });
+
+        it('custom streamType via custom content metadata', () => {
+          jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
+          convivaAnalytics.updateCustomContentMetadata({ custom: { streamType: 'dash_vod' } });
+          playerEventHelper.firePlayEvent();
+          expect(MockHelper.latestVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              streamType: 'dash_vod',
+            }),
+          );
+        });
+
+        it('required and custom streamType separately', () => {
+          jest.spyOn(playerMock, 'getStreamType').mockReturnValue(StreamType.Dash);
+          convivaAnalytics.updateRequiredContentMetadata({ streamType: Conviva.ContentMetadata.StreamType.UNKNOWN });
+          convivaAnalytics.updateCustomContentMetadata({ custom: { streamType: 'dash_vod' } });
+          playerEventHelper.firePlayEvent();
+          expect(MockHelper.latestVideoAnalytics.reportPlaybackRequested).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              isLive: 'unknown',
+              streamType: 'dash_vod',
             }),
           );
         });

--- a/src/ts/ContentMetadataBuilder.ts
+++ b/src/ts/ContentMetadataBuilder.ts
@@ -14,10 +14,14 @@ export type Metadata = Conviva.ContentMetadata & {
   additionalStandardTags: Conviva.ContentMetadata['custom'];
 };
 
+export type RequiredMetadata = Omit<Metadata, 'custom' | 'additionalStandardTags'>;
+export type CustomMetadata = Pick<Metadata, 'custom' | 'additionalStandardTags'>;
+
 export class ContentMetadataBuilder {
   private readonly logger: Conviva.LoggingInterface;
 
   private metadataOverrides: Partial<Metadata> = {};
+  private customMetadataOverrides: Partial<CustomMetadata> = {};
   private metadata: Partial<Metadata> = {};
   private latestBuiltMetadata: Partial<Metadata> = {};
   private playbackStarted: boolean = false;
@@ -39,6 +43,18 @@ export class ContentMetadataBuilder {
     }
 
     this.metadataOverrides = { ...this.metadataOverrides, ...newValue };
+  }
+
+  setCustomOverrides(newValue: Partial<CustomMetadata>) {
+    if (this.playbackStarted) {
+      this.logger.consoleLog(
+        '[ Conviva Analytics ] Playback has started. Custom metadata overrides will not be applied',
+        Conviva.SystemSettings.LogLevel.WARNING,
+      );
+      return;
+    }
+
+    this.customMetadataOverrides = { ...this.customMetadataOverrides, ...newValue };
   }
 
   getOverrides(): Partial<Metadata> {
@@ -67,6 +83,9 @@ export class ContentMetadataBuilder {
         ...this.metadataOverrides.additionalStandardTags,
         // Keep our custom tags in case someone tries to override them
         ...this.metadata.custom,
+        // Explicit custom metadata updates should be able to override the internally populated custom tags.
+        ...this.customMetadataOverrides.custom,
+        ...this.customMetadataOverrides.additionalStandardTags,
       };
     } else {
       // If the playback has been started, the values cannot be changed and the latest values before the playback started have to be used
@@ -166,6 +185,7 @@ export class ContentMetadataBuilder {
 
   public reset(): void {
     this.metadataOverrides = {};
+    this.customMetadataOverrides = {};
     this.metadata = {};
     this.playbackStarted = false;
     this.latestBuiltMetadata = {};

--- a/src/ts/ConvivaAnalytics.ts
+++ b/src/ts/ConvivaAnalytics.ts
@@ -13,7 +13,7 @@ import {
   VideoQualityChangedEvent,
   SubtitleEvent,
 } from 'bitmovin-player';
-import { Metadata } from './ContentMetadataBuilder';
+import { CustomMetadata, Metadata, RequiredMetadata } from './ContentMetadataBuilder';
 import { ObjectUtils } from './helper/ObjectUtils';
 import { ConvivaAnalyticsConfiguration, ConvivaAnalyticsTracker, EventAttributes } from './ConvivaAnalyticsTracker';
 import { ConvivaAnalyticsSsai } from './ConvivaAnalyticsSsai';
@@ -173,12 +173,39 @@ export class ConvivaAnalytics {
    * If there is an active session only permitted values will be updated and propagated immediately.
    * If there is no active session the values will set on session creation.
    *
-   * Attributes set via this method will override automatic tracked once.
+   * Attributes set via this method will override automatically tracked values.
    * @param metadataOverrides Metadata attributes which will be used to track to conviva.
    * @see ContentMetadataBuilder for more information about permitted attributes
    */
   public updateContentMetadata(metadataOverrides: Partial<Metadata>) {
     this.convivaAnalyticsTracker.updateContentMetadata(metadataOverrides);
+  }
+
+  /**
+   * Will update Conviva-managed content metadata without changing custom metadata fields.
+   *
+   * If there is an active session only permitted values will be updated and propagated immediately.
+   * If there is no active session the values will be set on session creation.
+   *
+   * Attributes set via this method will override automatically tracked values.
+   * @param metadataOverrides Conviva-managed metadata attributes which will be used to track to conviva.
+   * @see ContentMetadataBuilder for more information about permitted attributes
+   */
+  public updateRequiredContentMetadata(metadataOverrides: Partial<RequiredMetadata>) {
+    this.convivaAnalyticsTracker.updateRequiredContentMetadata(metadataOverrides);
+  }
+
+  /**
+   * Will update custom content metadata without changing Conviva-managed metadata fields.
+   *
+   * If there is an active session only permitted values will be updated and propagated immediately.
+   * If there is no active session the values will be set on session creation.
+   *
+   * @param metadataOverrides Custom metadata attributes which will be used to track to conviva.
+   * @see ContentMetadataBuilder for more information about permitted attributes
+   */
+  public updateCustomContentMetadata(metadataOverrides: Partial<CustomMetadata>) {
+    this.convivaAnalyticsTracker.updateCustomContentMetadata(metadataOverrides);
   }
 
   /**

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -17,7 +17,7 @@ import { Html5Storage } from './Html5Storage';
 import { Html5Time } from './Html5Time';
 import { Html5Timer } from './Html5Timer';
 import { Timeout } from 'bitmovin-player-ui/dist/js/framework/timeout';
-import { ContentMetadataBuilder, Metadata } from './ContentMetadataBuilder';
+import { ContentMetadataBuilder, CustomMetadata, Metadata, RequiredMetadata } from './ContentMetadataBuilder';
 import { AdHelper } from './helper/AdHelper';
 import { PlayerEventWrapper } from './helper/PlayerEventWrapper';
 import { PlayerConfigHelper } from './helper/PlayerConfigHelper';
@@ -370,6 +370,14 @@ export class ConvivaAnalyticsTracker {
     this.internalUpdateContentMetadata(metadataOverrides);
   }
 
+  public updateRequiredContentMetadata(metadataOverrides: Partial<RequiredMetadata>) {
+    this.internalUpdateContentMetadata(metadataOverrides);
+  }
+
+  public updateCustomContentMetadata(metadataOverrides: Partial<CustomMetadata>) {
+    this.internalUpdateCustomContentMetadata(metadataOverrides);
+  }
+
   public reportPlaybackDeficiency(
     message: string,
     severity: Conviva.valueof<Conviva.ConvivaConstants['ErrorSeverity']>,
@@ -444,9 +452,12 @@ export class ConvivaAnalyticsTracker {
     }
   }
 
-  private internalUpdateContentMetadata(metadataOverrides: Partial<Metadata>) {
-    this.contentMetadataBuilder.setOverrides(metadataOverrides);
-
+  /**
+   * Applies a content metadata builder update; if a session is active, rebuilds metadata and updates the session.
+   * If no session is active, logs and defers propagation to session initialization.
+   */
+  private applyContentMetadataUpdate(updateBuilder: () => void): void {
+    updateBuilder();
     if (!this.isSessionActive()) {
       this.logger.consoleLog(
         '[ ConvivaAnalyticsTracker ] no active session. Content metadata will be propagated to Conviva on session initialization.',
@@ -454,9 +465,16 @@ export class ConvivaAnalyticsTracker {
       );
       return;
     }
-
     this.buildContentMetadata();
     this.updateSession();
+  }
+
+  private internalUpdateContentMetadata(metadataOverrides: Partial<Metadata>) {
+    this.applyContentMetadataUpdate(() => this.contentMetadataBuilder.setOverrides(metadataOverrides));
+  }
+
+  private internalUpdateCustomContentMetadata(metadataOverrides: Partial<CustomMetadata>) {
+    this.applyContentMetadataUpdate(() => this.contentMetadataBuilder.setCustomOverrides(metadataOverrides));
   }
 
   /**

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -3,5 +3,5 @@ import './conviva/ConvivaExtension';
 
 export { ConvivaAnalyticsConfiguration, EventAttributes } from './ConvivaAnalyticsTracker';
 export { ConvivaAnalytics } from './ConvivaAnalytics';
-export { Metadata } from './ContentMetadataBuilder';
+export { CustomMetadata, Metadata, RequiredMetadata } from './ContentMetadataBuilder';
 export { SsaiAdInfo } from './helper/AdHelper';


### PR DESCRIPTION
## Description
This change adds separate update paths for required metadata and custom metadata in the Conviva Bitmovin SDK integration.

Previously, metadata fields with the same name could overwrite each other when required and custom metadata were updated together. By adding the option to update these independently, we avoid unintended overrides and ensure both metadata sets are preserved correctly.

(linting/formatting also made some updates in markdown files)

<!-- Add details of the bug/feature here, and how you fixed it -->

## Checklist
- [x] `CHANGELOG.md` entry added
- [x] Tests added (or covered by existing ones)