### PR TITLE
feature: Capture full error details when reporting playback failures …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Playback error messages reported to Conviva now include the full error context (message, type, timestamp, troubleshoot link, and all relevant `event.data` fields such as `url`, `httpStatusCode`, `statusText`, `downloadType`, etc.) instead of only the error code and name
+  - Sensitive query-string parameters (`token`, `sig`, `signature`, `apikey`, etc.) in URL fields are redacted before being forwarded
+  - Sensitive HTTP headers (`Authorization`, `Cookie`, `X-Api-Key`, etc.) in `responseHeaders` are redacted before being forwarded
+  - Long field values are truncated to 512 characters to avoid bloating the reported message
 
 ## [6.2.0] - 2026-03-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Playback error messages reported to Conviva now include the full error context (message, type, timestamp, troubleshoot link, and all relevant `event.data` fields such as `url`, `httpStatusCode`, `statusText`, `downloadType`, etc.) instead of only the error code and name
 
 ## [6.2.0] - 2026-03-18
 ### Added

--- a/spec/tests/ErrorHelper.spec.ts
+++ b/spec/tests/ErrorHelper.spec.ts
@@ -1,0 +1,136 @@
+import { ErrorCode, PlayerEvent } from 'bitmovin-player';
+import { ErrorHelper } from '../../src/ts/helper/ErrorHelper';
+
+describe(ErrorHelper, () => {
+  describe('formatPlaybackError', () => {
+    it('should format minimal error with only code and name', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+      });
+
+      expect(result).toContain('Error code: 1400;');
+      expect(result).toContain('Name: NETWORK_ERROR;');
+      expect(result).toContain('Type: error;');
+      expect(result).toContain('Timestamp: 1700000000000;');
+      expect(result).not.toContain('Troubleshoot link:');
+    });
+
+    it('should include message and troubleshoot link when present', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        message: 'Network failure',
+        troubleShootLink: 'https://bitmovin.com/troubleshoot/1400',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+      });
+
+      expect(result).toContain('Message: Network failure;');
+      expect(result).toContain('Troubleshoot link: https://bitmovin.com/troubleshoot/1400;');
+    });
+
+    it('should extract URL and HTTP status from event.data', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        message: 'Segment download failed',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          url: 'https://cdn.example.com/segment_1.ts',
+          httpStatusCode: 404,
+          statusText: 'Not Found',
+          downloadType: 'media/video',
+        },
+      });
+
+      expect(result).toContain('url: https://cdn.example.com/segment_1.ts;');
+      expect(result).toContain('httpStatusCode: 404;');
+      expect(result).toContain('statusText: Not Found;');
+      expect(result).toContain('downloadType: media/video;');
+    });
+
+    it('should serialize unknown data fields under "data:"', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          url: 'https://cdn.example.com/manifest.m3u8',
+          customField: { nested: 'value' },
+          anotherCustomField: 42,
+        },
+      });
+
+      expect(result).toContain('url: https://cdn.example.com/manifest.m3u8;');
+      expect(result).toContain('data: {"customField":{"nested":"value"},"anotherCustomField":42};');
+    });
+
+    it('should handle non-object data values', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.SOURCE_ERROR,
+        name: 'SOURCE_ERROR',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: 'something went wrong',
+      } as any);
+
+      expect(result).toContain('data: something went wrong;');
+    });
+
+    it('should handle circular references in data', () => {
+      const circular: any = { url: 'https://cdn.example.com/x', extra: {} };
+      circular.extra.self = circular;
+
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: circular,
+      });
+
+      expect(result).toContain('url: https://cdn.example.com/x;');
+      expect(result).toContain('[Circular]');
+    });
+
+    it('should fall back to "NA" for missing code and name', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+      } as any);
+
+      expect(result).toContain('Error code: NA;');
+      expect(result).toContain('Name: NA;');
+    });
+
+    it('should skip null, undefined, and empty data values', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          url: 'https://cdn.example.com/x',
+          httpStatusCode: null,
+          statusText: '',
+          response: undefined,
+        },
+      });
+
+      expect(result).toContain('url: https://cdn.example.com/x;');
+      expect(result).not.toContain('httpStatusCode:');
+      expect(result).not.toContain('statusText:');
+      expect(result).not.toContain('response:');
+    });
+  });
+});

--- a/spec/tests/ErrorHelper.spec.ts
+++ b/spec/tests/ErrorHelper.spec.ts
@@ -166,6 +166,50 @@ describe(ErrorHelper, () => {
       expect(result).not.toContain('deadbeef');
     });
 
+    it('should redact sensitive URL fragment params (OAuth implicit grant)', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          url: 'https://cdn.example.com/player.html#access_token=oauth-secret&expires_in=3600',
+        },
+      });
+
+      expect(result).toContain('access_token=[REDACTED]');
+      expect(result).toContain('expires_in=3600');
+      expect(result).not.toContain('oauth-secret');
+    });
+
+    it('should redact common CDN signed-URL params (CloudFront / Akamai)', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          url:
+            'https://cdn.example.com/video.mp4?X-Amz-Signature=cf-sig&Policy=cf-policy&' +
+            'Key-Pair-Id=KEYID&hdnts=ak-token&__token__=generic-tok&region=eu',
+        },
+      });
+
+      expect(result).toContain('X-Amz-Signature=[REDACTED]');
+      expect(result).toContain('Policy=[REDACTED]');
+      expect(result).toContain('Key-Pair-Id=[REDACTED]');
+      expect(result).toContain('hdnts=[REDACTED]');
+      expect(result).toContain('__token__=[REDACTED]');
+      expect(result).toContain('region=eu');
+      expect(result).not.toContain('cf-sig');
+      expect(result).not.toContain('cf-policy');
+      expect(result).not.toContain('KEYID');
+      expect(result).not.toContain('ak-token');
+      expect(result).not.toContain('generic-tok');
+    });
+
     it('should redact sensitive HTTP headers in responseHeaders', () => {
       const result = ErrorHelper.formatPlaybackError({
         code: ErrorCode.NETWORK_ERROR,

--- a/spec/tests/ErrorHelper.spec.ts
+++ b/spec/tests/ErrorHelper.spec.ts
@@ -132,5 +132,121 @@ describe(ErrorHelper, () => {
       expect(result).not.toContain('statusText:');
       expect(result).not.toContain('response:');
     });
+
+    it('should keep timestamp 0 and empty-string type instead of dropping them', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 0,
+        type: '' as any,
+      });
+
+      expect(result).toContain('Timestamp: 0;');
+      expect(result).toContain('Type: ;');
+    });
+
+    it('should redact sensitive query-string parameters in URL fields', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          url: 'https://cdn.example.com/asset.m3u8?token=abc123&region=eu&sig=deadbeef',
+        },
+      });
+
+      expect(result).toContain('https://cdn.example.com/asset.m3u8?');
+      expect(result).toContain('token=[REDACTED]');
+      expect(result).toContain('sig=[REDACTED]');
+      expect(result).toContain('region=eu');
+      expect(result).not.toContain('abc123');
+      expect(result).not.toContain('deadbeef');
+    });
+
+    it('should redact sensitive HTTP headers in responseHeaders', () => {
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          responseHeaders: {
+            'Content-Type': 'video/mp4',
+            Authorization: 'Bearer super-secret-token',
+            Cookie: 'session=abc',
+            'X-Api-Key': 'k-1234',
+          },
+        },
+      });
+
+      expect(result).toContain('Content-Type');
+      expect(result).toContain('video/mp4');
+      expect(result).toContain('"Authorization":"[REDACTED]"');
+      expect(result).toContain('"Cookie":"[REDACTED]"');
+      expect(result).toContain('"X-Api-Key":"[REDACTED]"');
+      expect(result).not.toContain('super-secret-token');
+      expect(result).not.toContain('session=abc');
+      expect(result).not.toContain('k-1234');
+    });
+
+    it('should truncate very long known field values', () => {
+      const longBody = 'x'.repeat(2000);
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          responseText: longBody,
+        },
+      });
+
+      expect(result).toContain('[truncated');
+      expect(result).not.toContain(longBody);
+    });
+
+    it('should serialize BigInt values in known fields and remaining data', () => {
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const globalRef = Function('return this')() as { BigInt?: (v: string) => unknown };
+      const BigIntCtor = globalRef.BigInt;
+      if (typeof BigIntCtor !== 'function') {
+        // Skip on platforms without BigInt support.
+        return;
+      }
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: {
+          retryCount: BigIntCtor('9007199254740993'),
+          customCounter: BigIntCtor('12345678901234567890'),
+        },
+      });
+
+      expect(result).toContain('retryCount: 9007199254740993;');
+      expect(result).toContain('"customCounter":"12345678901234567890"');
+    });
+
+    it('should not produce "undefined" output for unserializable data values', () => {
+      const symbolValue: any = Symbol('only-a-symbol');
+      const result = ErrorHelper.formatPlaybackError({
+        code: ErrorCode.NETWORK_ERROR,
+        name: 'NETWORK_ERROR',
+        troubleShootLink: '',
+        timestamp: 1700000000000,
+        type: PlayerEvent.Error,
+        data: symbolValue,
+      });
+
+      expect(result).not.toContain('undefined');
+      expect(result).toContain('data:');
+    });
   });
 });

--- a/src/ts/ConvivaAnalyticsTracker.ts
+++ b/src/ts/ConvivaAnalyticsTracker.ts
@@ -19,6 +19,7 @@ import { Html5Timer } from './Html5Timer';
 import { Timeout } from 'bitmovin-player-ui/dist/js/framework/timeout';
 import { ContentMetadataBuilder, CustomMetadata, Metadata, RequiredMetadata } from './ContentMetadataBuilder';
 import { AdHelper } from './helper/AdHelper';
+import { ErrorHelper } from './helper/ErrorHelper';
 import { PlayerEventWrapper } from './helper/PlayerEventWrapper';
 import { PlayerConfigHelper } from './helper/PlayerConfigHelper';
 import { PlayerStateHelper } from './helper/PlayerStateHelper';
@@ -970,8 +971,12 @@ export class ConvivaAnalyticsTracker {
       this.internalInitializeSession();
     }
 
-    this.debugLog('[ ConvivaAnalyticsTracker ] report playback deficiency', event);
-    this.reportPlaybackDeficiency(String(event.code) + ' ' + event.name, Conviva.Constants.ErrorSeverity.FATAL);
+    const formattedError = ErrorHelper.formatPlaybackError(event);
+    this.debugLog('[ ConvivaAnalyticsTracker ] report playback deficiency', {
+      event,
+      formattedError,
+    });
+    this.reportPlaybackDeficiency(formattedError, Conviva.Constants.ErrorSeverity.FATAL);
   };
 
   private onSourceUnloaded = (event: PlayerEventBase) => {

--- a/src/ts/helper/ErrorHelper.ts
+++ b/src/ts/helper/ErrorHelper.ts
@@ -1,11 +1,5 @@
 import { ErrorEvent } from 'bitmovin-player';
 
-type ErrorEventWithData = ErrorEvent & {
-  message?: string;
-  troubleShootLink?: string;
-  data?: any;
-};
-
 const KNOWN_DATA_KEYS = [
   'url',
   'requestUrl',
@@ -33,9 +27,10 @@ const KNOWN_DATA_KEYS = [
 
 const URL_LIKE_KEYS = ['url', 'requestUrl', 'manifestUrl', 'segmentUrl', 'responseUrl'];
 const HEADER_LIKE_KEYS = ['responseHeaders'];
-const RESPONSE_BODY_KEYS = ['response', 'responseText'];
 
-// Query-string parameter names that commonly carry credentials in signed-URL schemes.
+// Query-string parameter names that commonly carry credentials in signed-URL
+// schemes — generic OAuth/JWT-style names plus the common CDN signed-URL
+// schemes (CloudFront/S3, Akamai, generic __token__).
 const SENSITIVE_QUERY_PARAMS = [
   'token',
   'access_token',
@@ -53,6 +48,17 @@ const SENSITIVE_QUERY_PARAMS = [
   'sessionid',
   'jwt',
   'bearer',
+  // CloudFront / S3 signed URLs.
+  'x-amz-signature',
+  'x-amz-security-token',
+  'x-amz-credential',
+  'policy',
+  'key-pair-id',
+  'keypairid',
+  // Akamai / generic CDN tokens.
+  'hdnts',
+  'hdnea',
+  '__token__',
 ];
 
 // HTTP header names that commonly carry credentials or session identifiers.
@@ -74,32 +80,55 @@ function truncate(value: string): string {
   if (value.length <= MAX_FIELD_LENGTH) {
     return value;
   }
-  return `${value.slice(0, MAX_FIELD_LENGTH)}…[truncated ${value.length - MAX_FIELD_LENGTH} chars]`;
+  return `${value.slice(0, MAX_FIELD_LENGTH)}...[truncated ${value.length - MAX_FIELD_LENGTH} chars]`;
+}
+
+function redactKeyValueList(list: string): string {
+  return list
+    .split('&')
+    .map((pair) => {
+      const eq = pair.indexOf('=');
+      if (eq === -1) {
+        return pair;
+      }
+      const name = pair.slice(0, eq);
+      const val = pair.slice(eq + 1);
+      if (SENSITIVE_QUERY_PARAMS.indexOf(name.toLowerCase()) !== -1) {
+        return `${name}=${REDACTED}`;
+      }
+      return `${name}=${val}`;
+    })
+    .join('&');
 }
 
 function sanitizeUrl(value: unknown): string {
   if (typeof value !== 'string') {
     return truncate(safeStringify(value));
   }
-  const queryIndex = value.indexOf('?');
+
+  // Sensitive data can live in the query (?...) AND the fragment (#...), the
+  // latter being how OAuth implicit-grant flows leak access tokens. Sanitize
+  // both — split on '#' first so the fragment is processed even when there is
+  // no query string.
+  const fragmentIndex = value.indexOf('#');
+  const beforeFragment = fragmentIndex === -1 ? value : value.slice(0, fragmentIndex);
+  const fragment = fragmentIndex === -1 ? '' : value.slice(fragmentIndex + 1);
+
+  let sanitized: string;
+  const queryIndex = beforeFragment.indexOf('?');
   if (queryIndex === -1) {
-    return truncate(value);
+    sanitized = beforeFragment;
+  } else {
+    const base = beforeFragment.slice(0, queryIndex);
+    const query = beforeFragment.slice(queryIndex + 1);
+    sanitized = `${base}?${redactKeyValueList(query)}`;
   }
-  const base = value.slice(0, queryIndex);
-  const query = value.slice(queryIndex + 1);
-  const sanitizedPairs = query.split('&').map((pair) => {
-    const eq = pair.indexOf('=');
-    if (eq === -1) {
-      return pair;
-    }
-    const name = pair.slice(0, eq);
-    const val = pair.slice(eq + 1);
-    if (SENSITIVE_QUERY_PARAMS.indexOf(name.toLowerCase()) !== -1) {
-      return `${name}=${REDACTED}`;
-    }
-    return `${name}=${val}`;
-  });
-  return truncate(`${base}?${sanitizedPairs.join('&')}`);
+
+  if (fragment) {
+    sanitized = `${sanitized}#${redactKeyValueList(fragment)}`;
+  }
+
+  return truncate(sanitized);
 }
 
 function sanitizeHeaders(value: unknown): string {
@@ -123,9 +152,6 @@ function sanitizeKnownField(key: string, value: unknown): string {
   }
   if (HEADER_LIKE_KEYS.indexOf(key) !== -1) {
     return sanitizeHeaders(value);
-  }
-  if (RESPONSE_BODY_KEYS.indexOf(key) !== -1) {
-    return truncate(safeStringify(value));
   }
   return truncate(safeStringify(value));
 }
@@ -178,7 +204,7 @@ function safeStringify(value: unknown): string {
 }
 
 export class ErrorHelper {
-  public static formatPlaybackError(event: ErrorEventWithData): string {
+  public static formatPlaybackError(event: ErrorEvent): string {
     const parts: (string | undefined)[] = [
       `Error code: ${event?.code ?? 'NA'};`,
       `Name: ${event?.name ?? 'NA'};`,
@@ -189,12 +215,15 @@ export class ErrorHelper {
       event?.timestamp !== undefined && event?.timestamp !== null ? `Timestamp: ${event.timestamp};` : undefined,
     ];
 
-    const data = event?.data;
+    // Widen to `unknown` so the runtime safety paths below (handling
+    // non-object data that may still arrive at runtime despite the typed
+    // `event.data: { [key: string]: any } | undefined`) compile.
+    const data: unknown = event?.data;
     if (data && typeof data === 'object') {
       const extracted: string[] = [];
       const remaining: Record<string, unknown> = {};
 
-      for (const key of Object.keys(data)) {
+      for (const key of Object.keys(data as Record<string, unknown>)) {
         const value = (data as Record<string, unknown>)[key];
         if (value === undefined || value === null || value === '') {
           continue;

--- a/src/ts/helper/ErrorHelper.ts
+++ b/src/ts/helper/ErrorHelper.ts
@@ -31,6 +31,105 @@ const KNOWN_DATA_KEYS = [
   'retryCount',
 ];
 
+const URL_LIKE_KEYS = ['url', 'requestUrl', 'manifestUrl', 'segmentUrl', 'responseUrl'];
+const HEADER_LIKE_KEYS = ['responseHeaders'];
+const RESPONSE_BODY_KEYS = ['response', 'responseText'];
+
+// Query-string parameter names that commonly carry credentials in signed-URL schemes.
+const SENSITIVE_QUERY_PARAMS = [
+  'token',
+  'access_token',
+  'auth',
+  'authorization',
+  'sig',
+  'signature',
+  'hmac',
+  'key',
+  'apikey',
+  'api_key',
+  'password',
+  'secret',
+  'session',
+  'sessionid',
+  'jwt',
+  'bearer',
+];
+
+// HTTP header names that commonly carry credentials or session identifiers.
+const SENSITIVE_HEADER_NAMES = [
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+  'x-csrf-token',
+  'x-session-id',
+];
+
+const REDACTED = '[REDACTED]';
+const MAX_FIELD_LENGTH = 512;
+
+function truncate(value: string): string {
+  if (value.length <= MAX_FIELD_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_FIELD_LENGTH)}…[truncated ${value.length - MAX_FIELD_LENGTH} chars]`;
+}
+
+function sanitizeUrl(value: unknown): string {
+  if (typeof value !== 'string') {
+    return truncate(safeStringify(value));
+  }
+  const queryIndex = value.indexOf('?');
+  if (queryIndex === -1) {
+    return truncate(value);
+  }
+  const base = value.slice(0, queryIndex);
+  const query = value.slice(queryIndex + 1);
+  const sanitizedPairs = query.split('&').map((pair) => {
+    const eq = pair.indexOf('=');
+    if (eq === -1) {
+      return pair;
+    }
+    const name = pair.slice(0, eq);
+    const val = pair.slice(eq + 1);
+    if (SENSITIVE_QUERY_PARAMS.indexOf(name.toLowerCase()) !== -1) {
+      return `${name}=${REDACTED}`;
+    }
+    return `${name}=${val}`;
+  });
+  return truncate(`${base}?${sanitizedPairs.join('&')}`);
+}
+
+function sanitizeHeaders(value: unknown): string {
+  if (!value || typeof value !== 'object') {
+    return truncate(safeStringify(value));
+  }
+  const sanitized: Record<string, unknown> = {};
+  for (const headerName of Object.keys(value as Record<string, unknown>)) {
+    if (SENSITIVE_HEADER_NAMES.indexOf(headerName.toLowerCase()) !== -1) {
+      sanitized[headerName] = REDACTED;
+    } else {
+      sanitized[headerName] = (value as Record<string, unknown>)[headerName];
+    }
+  }
+  return truncate(safeStringify(sanitized));
+}
+
+function sanitizeKnownField(key: string, value: unknown): string {
+  if (URL_LIKE_KEYS.indexOf(key) !== -1) {
+    return sanitizeUrl(value);
+  }
+  if (HEADER_LIKE_KEYS.indexOf(key) !== -1) {
+    return sanitizeHeaders(value);
+  }
+  if (RESPONSE_BODY_KEYS.indexOf(key) !== -1) {
+    return truncate(safeStringify(value));
+  }
+  return truncate(safeStringify(value));
+}
+
 function safeStringify(value: unknown): string {
   if (value === null || value === undefined) {
     return '';
@@ -41,9 +140,12 @@ function safeStringify(value: unknown): string {
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
   }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
   try {
     const seen = new WeakSet<object>();
-    return JSON.stringify(value, (_key, val) => {
+    const result = JSON.stringify(value, (_key, val) => {
       if (typeof val === 'object' && val !== null) {
         if (seen.has(val)) {
           return '[Circular]';
@@ -55,6 +157,17 @@ function safeStringify(value: unknown): string {
       }
       return val;
     });
+    // JSON.stringify returns undefined for unsupported root values (functions,
+    // symbols, top-level undefined). Coalesce to a defined string so the
+    // function's return contract holds.
+    if (result === undefined) {
+      try {
+        return String(value);
+      } catch {
+        return '[Unserializable]';
+      }
+    }
+    return result;
   } catch {
     try {
       return String(value);
@@ -70,8 +183,10 @@ export class ErrorHelper {
       `Error code: ${event?.code ?? 'NA'};`,
       `Name: ${event?.name ?? 'NA'};`,
       event?.message ? `Message: ${event.message};` : undefined,
-      event?.type ? `Type: ${event.type};` : undefined,
-      event?.timestamp ? `Timestamp: ${event.timestamp};` : undefined,
+      // Explicit nullish check so legitimate falsy values (timestamp === 0,
+      // type === '') are still reported instead of being silently dropped.
+      event?.type !== undefined && event?.type !== null ? `Type: ${event.type};` : undefined,
+      event?.timestamp !== undefined && event?.timestamp !== null ? `Timestamp: ${event.timestamp};` : undefined,
     ];
 
     const data = event?.data;
@@ -85,7 +200,7 @@ export class ErrorHelper {
           continue;
         }
         if (KNOWN_DATA_KEYS.indexOf(key) !== -1) {
-          extracted.push(`${key}: ${safeStringify(value)};`);
+          extracted.push(`${key}: ${sanitizeKnownField(key, value)};`);
         } else {
           remaining[key] = value;
         }
@@ -94,10 +209,10 @@ export class ErrorHelper {
       parts.push(...extracted);
 
       if (Object.keys(remaining).length > 0) {
-        parts.push(`data: ${safeStringify(remaining)};`);
+        parts.push(`data: ${truncate(safeStringify(remaining))};`);
       }
     } else if (data !== undefined && data !== null && data !== '') {
-      parts.push(`data: ${safeStringify(data)};`);
+      parts.push(`data: ${truncate(safeStringify(data))};`);
     }
 
     if (event?.troubleShootLink) {

--- a/src/ts/helper/ErrorHelper.ts
+++ b/src/ts/helper/ErrorHelper.ts
@@ -1,0 +1,109 @@
+import { ErrorEvent } from 'bitmovin-player';
+
+type ErrorEventWithData = ErrorEvent & {
+  message?: string;
+  troubleShootLink?: string;
+  data?: any;
+};
+
+const KNOWN_DATA_KEYS = [
+  'url',
+  'requestUrl',
+  'manifestUrl',
+  'segmentUrl',
+  'httpStatusCode',
+  'statusCode',
+  'status',
+  'statusText',
+  'response',
+  'responseText',
+  'responseUrl',
+  'responseHeaders',
+  'downloadType',
+  'mimeType',
+  'method',
+  'reason',
+  'details',
+  'cause',
+  'errorMessage',
+  'errorCode',
+  'subCode',
+  'retryCount',
+];
+
+function safeStringify(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(value, (_key, val) => {
+      if (typeof val === 'object' && val !== null) {
+        if (seen.has(val)) {
+          return '[Circular]';
+        }
+        seen.add(val);
+      }
+      if (typeof val === 'bigint') {
+        return val.toString();
+      }
+      return val;
+    });
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return '[Unserializable]';
+    }
+  }
+}
+
+export class ErrorHelper {
+  public static formatPlaybackError(event: ErrorEventWithData): string {
+    const parts: (string | undefined)[] = [
+      `Error code: ${event?.code ?? 'NA'};`,
+      `Name: ${event?.name ?? 'NA'};`,
+      event?.message ? `Message: ${event.message};` : undefined,
+      event?.type ? `Type: ${event.type};` : undefined,
+      event?.timestamp ? `Timestamp: ${event.timestamp};` : undefined,
+    ];
+
+    const data = event?.data;
+    if (data && typeof data === 'object') {
+      const extracted: string[] = [];
+      const remaining: Record<string, unknown> = {};
+
+      for (const key of Object.keys(data)) {
+        const value = (data as Record<string, unknown>)[key];
+        if (value === undefined || value === null || value === '') {
+          continue;
+        }
+        if (KNOWN_DATA_KEYS.indexOf(key) !== -1) {
+          extracted.push(`${key}: ${safeStringify(value)};`);
+        } else {
+          remaining[key] = value;
+        }
+      }
+
+      parts.push(...extracted);
+
+      if (Object.keys(remaining).length > 0) {
+        parts.push(`data: ${safeStringify(remaining)};`);
+      }
+    } else if (data !== undefined && data !== null && data !== '') {
+      parts.push(`data: ${safeStringify(data)};`);
+    }
+
+    if (event?.troubleShootLink) {
+      parts.push(`Troubleshoot link: ${event.troubleShootLink};`);
+    }
+
+    return parts.filter(Boolean).join(' ');
+  }
+}


### PR DESCRIPTION
Description
Summary
Improves field triage. When a playback failure is reported to Conviva, ConvivaAnalyticsTracker.trackError currently forwards only event.code and event.name to reportPlaybackFailed. In production this means operators looking at a Conviva session see something like 1400 SOURCE_ERROR with no indication of which URL failed, what HTTP status came back, or any of the contextual fields the player attaches to event.data — so triaging a stream issue means asking the field team to reproduce and capture player logs.

This PR introduces ErrorHelper.formatPlaybackError and uses it from trackError, so the message reported to Conviva carries the full context the player already has on hand:

code, name, message, type, timestamp
troubleShootLink when present
All known network/HTTP fields from event.data: url, requestUrl, manifestUrl, segmentUrl, httpStatusCode / statusCode / status, statusText, response, responseText, responseUrl, responseHeaders, downloadType, mimeType, method, reason, details, cause, errorMessage, errorCode, subCode, retryCount
Any remaining keys in event.data are JSON-stringified under a data: segment so nothing is silently dropped
Safe stringify handles circular references and BigInt
Example — a 404 on a media segment.

Before:

1400 SOURCE_ERROR

After:

Error code: 1400; Name: SOURCE_ERROR; Message: Segment download failed; Type: error; Timestamp: 1700000000000; url: https://cdn.example.com/segment_1.ts; httpStatusCode: 404; statusText: Not Found; downloadType: media/video;

Nothing about the public API or session lifecycle changes — only the content of the message string passed to reportPlaybackFailed.